### PR TITLE
Expose ACRA config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:4.0.4'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:4.0.4'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:4.1.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:4.1.0'
 }
 ```
 

--- a/kumulos/src/main/java/com/kumulos/android/AnalyticsBackgroundEventService.java
+++ b/kumulos/src/main/java/com/kumulos/android/AnalyticsBackgroundEventService.java
@@ -1,10 +1,14 @@
 package com.kumulos.android;
 
+import android.app.Application;
 import android.os.Bundle;
 
 import com.google.android.gms.gcm.GcmNetworkManager;
 import com.google.android.gms.gcm.GcmTaskService;
 import com.google.android.gms.gcm.TaskParams;
+
+import org.acra.ReportField;
+import org.acra.config.CoreConfigurationBuilder;
 
 public class AnalyticsBackgroundEventService extends GcmTaskService {
 
@@ -19,8 +23,21 @@ public class AnalyticsBackgroundEventService extends GcmTaskService {
         if (!Kumulos.isInitialized()) {
             Bundle configBundle = extras.getBundle(EXTRAS_KEY_CONFIG);
 
+            if (null == configBundle) {
+                return GcmNetworkManager.RESULT_FAILURE;
+            }
+
             KumulosConfig config = KumulosConfig.fromBundle(configBundle);
-            Kumulos.initialize(this.getApplication(), config);
+
+            Application application = getApplication();
+
+            if (config.crashReportingEnabled()) {
+                CoreConfigurationBuilder acraBuilder = config.getAcraConfigBuilder(application);
+                acraBuilder.setReportField(ReportField.USER_EMAIL, false);
+                acraBuilder.setReportField(ReportField.LOGCAT, false);
+            }
+
+            Kumulos.initialize(application, config);
         }
 
         long ts = extras.getLong(EXTRAS_KEY_TIMESTAMP);

--- a/kumulos/src/main/java/com/kumulos/android/Kumulos.java
+++ b/kumulos/src/main/java/com/kumulos/android/Kumulos.java
@@ -117,7 +117,7 @@ public final class Kumulos {
 
         if (config.crashReportingEnabled()) {
             // Crash reporting
-            CoreConfigurationBuilder acraConfig = new CoreConfigurationBuilder(application);
+            CoreConfigurationBuilder acraConfig = config.getAcraConfigBuilder(application);
             acraConfig
                     .setReportFormat(StringFormat.JSON)
                     .getPluginConfigurationBuilder(HttpSenderConfigurationBuilder.class)

--- a/kumulos/src/main/java/com/kumulos/android/KumulosConfig.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosConfig.java
@@ -1,10 +1,12 @@
 package com.kumulos.android;
 
+import android.app.Application;
 import android.os.Bundle;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
+import org.acra.config.CoreConfigurationBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -33,6 +35,8 @@ public final class KumulosConfig {
 
     private JSONObject runtimeInfo;
     private JSONObject sdkInfo;
+
+    private CoreConfigurationBuilder acraConfigBuilder;
 
     // Private constructor to discourage not using the Builder.
     private KumulosConfig() {}
@@ -91,6 +95,14 @@ public final class KumulosConfig {
 
     public JSONObject getSdkInfo() {
         return this.sdkInfo;
+    }
+
+    public CoreConfigurationBuilder getAcraConfigBuilder(Application application) {
+        if (null == this.acraConfigBuilder) {
+            this.acraConfigBuilder = new CoreConfigurationBuilder(application);
+        }
+
+        return this.acraConfigBuilder;
     }
 
     /** package */ Bundle toBundle() {


### PR DESCRIPTION
- Allow customising the base ACRA configuration used in Kumulos crash reporting
- In the background event sync service, limit the fields included in ACRA if the original process Kumulos was initialised in has been destroyed

To access the config builder methods in app projects, it is necessary for the ACRA library to be on the compiler's class path. Adding `compileOnly 'ch.acra:acra-http:5.1.3'` to the app's dependencies does the trick.