### PR TITLE
Update ACRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:4.1.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:4.1.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:4.1.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:4.1.1'
 }
 ```
 

--- a/kumulos/build.gradle
+++ b/kumulos/build.gradle
@@ -32,7 +32,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'
-    implementation "ch.acra:acra-http:5.1.3"
+    implementation "ch.acra:acra-http:5.2.1"
     implementation 'org.codehaus.jackson:jackson-mapper-asl:1.8.5'
     implementation 'com.google.android.gms:play-services-gcm:15.0.1'
 }


### PR DESCRIPTION
Due to a manifest merger tooling problem, FCM tokens were not being correctly received on newer Android API levels.

This is explained further in https://github.com/ACRA/acra/issues/662.

