### PR TITLE
Add media settings

### DIFF
--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -420,7 +420,13 @@ class InAppMessagePresenter {
                     wv.getSettings().setCacheMode(cacheMode);
 
                     wv.setBackgroundColor(android.graphics.Color.TRANSPARENT);
-                    wv.getSettings().setJavaScriptEnabled(true);
+
+                    WebSettings settings = wv.getSettings();
+                    settings.setJavaScriptEnabled(true);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1){
+                        settings.setMediaPlaybackRequiresUserGesture(false);
+                    }
+
                     wv.addJavascriptInterface(new InAppJavaScriptInterface(), InAppJavaScriptInterface.NAME);
 
                     wv.setWebViewClient(new WebViewClient() {


### PR DESCRIPTION
To allow seamless video playback for in-app messages, we don't want to require user interaction to play media.