### PR TITLE
Remove key listener when dialog dismissed

### DIFF
--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -251,6 +251,10 @@ class InAppMessagePresenter {
     }
 
     static void closeCurrentMessage(Context context){
+        if (dialog == null || messageQueue.isEmpty()){
+            return;
+        }
+
         InAppMessage message = messageQueue.get(0);
 
         InAppMessagePresenter.sendToClient(HOST_MESSAGE_TYPE_CLOSE_MESSAGE, null);
@@ -316,6 +320,7 @@ class InAppMessagePresenter {
     private static void closeDialog(Activity dialogActivity){
         if (dialog != null){
             unsetStatusBarColorForDialog(dialogActivity);
+            dialog.setOnKeyListener(null);
             dialog.dismiss();
         }
         dialog = null;


### PR DESCRIPTION
Bug: Message closed, dialog closed. Press back button --> crashes. 

Suppose because dialog is set to null, but object still exists for some time, so, when back button pressed listener calls close message. 

Fix:
1) remove listener
2) extra checks in `closeCurrentMessage`