### PR TITLE
Set in-app deep-link handler on KumulosInApp instead of in KumulosConfig

### DIFF
--- a/kumulos/src/main/java/com/kumulos/android/KumulosConfig.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosConfig.java
@@ -33,7 +33,6 @@ public final class KumulosConfig {
     private int notificationSmallIconId;
     private boolean crashReportingEnabled;
     private InAppConsentStrategy inAppConsentStrategy;
-    private InAppDeepLinkHandlerInterface inAppDeepLinkHandler;
     private int sessionIdleTimeoutSeconds;
 
     private JSONObject runtimeInfo;
@@ -82,10 +81,6 @@ public final class KumulosConfig {
         this.inAppConsentStrategy = strategy;
     }
 
-    private void setInAppDeepLinkHandler(InAppDeepLinkHandlerInterface handler) {
-        this.inAppDeepLinkHandler = handler;
-    }
-
     public String getApiKey() {
         return apiKey;
     }
@@ -124,9 +119,6 @@ public final class KumulosConfig {
 
     InAppConsentStrategy getInAppConsentStrategy() {
         return inAppConsentStrategy;
-    }
-    InAppDeepLinkHandlerInterface getInAppDeepLinkHandler() {
-        return inAppDeepLinkHandler;
     }
 
     /** package */ Bundle toBundle() {
@@ -187,7 +179,6 @@ public final class KumulosConfig {
         private int notificationSmallIconDrawableId = KumulosConfig.DEFAULT_NOTIFICATION_ICON_ID;
         private boolean enableCrashReporting = false;
         private InAppConsentStrategy consentStrategy = null;
-        private InAppDeepLinkHandlerInterface inAppDeepLinkHandler;
         private int sessionIdleTimeoutSeconds = KumulosConfig.DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS;
 
         private JSONObject runtimeInfo;
@@ -218,13 +209,6 @@ public final class KumulosConfig {
             this.consentStrategy = strategy;
             return this;
         }
-
-        public Builder setInAppDeepLinkHandler(InAppDeepLinkHandlerInterface handler) {
-            this.inAppDeepLinkHandler = handler;
-            return this;
-        }
-
-
 
         /**
          * The minimum amount of time the user has to have left the app for a session end event to be
@@ -269,7 +253,6 @@ public final class KumulosConfig {
             newConfig.setSdkInfo(this.sdkInfo);
 
             newConfig.setInAppConsentStrategy(consentStrategy);
-            newConfig.setInAppDeepLinkHandler(this.inAppDeepLinkHandler);
 
             return newConfig;
         }

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -59,6 +59,14 @@ public class KumulosInApp {
         }
     }
 
+    /**
+     * Allows setting the handler you want to use for in-app deep-link buttons
+     * @param handler
+     */
+    public static void setDeepLinkHandler(InAppDeepLinkHandlerInterface handler) {
+        inAppDeepLinkHandler = handler;
+    }
+
     
     //==============================================================================================
     //-- Internal Helpers
@@ -81,8 +89,6 @@ public class KumulosInApp {
         }
 
         toggleInAppMessageMonitoring(inAppEnabled);
-
-        inAppDeepLinkHandler = currentConfig.getInAppDeepLinkHandler();
     }
 
     private static void updateInAppEnablementFlags(boolean enabled){


### PR DESCRIPTION
This avoids need to place the complex type in the Bundle for late initialisation
from onRunTask in background services.