### PR TITLE
Push action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:8.4.1'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:8.4.1'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:8.4.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:8.4.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:8.3.1'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:8.3.1'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:8.4.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:8.4.1'
 }
 ```
 

--- a/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
+++ b/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
@@ -3,9 +3,11 @@ package com.kumulos.android;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.util.Log;
 
 import com.google.firebase.messaging.RemoteMessage;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -43,12 +45,15 @@ public class FirebaseMessageHandler {
         JSONObject custom;
         Uri uri;
         String pictureUrl = bundle.get("bicon");
+        JSONArray buttons;
 
         try {
             custom = new JSONObject(customStr);
             uri = (!custom.isNull("u")) ? Uri.parse(custom.getString("u")) : null;
             data = custom.optJSONObject("a");
             id = data.getJSONObject("k.message").getJSONObject("data").getInt("id");
+            buttons = data.optJSONArray("k.buttons");
+
         } catch (JSONException e) {
             Kumulos.log(TAG, "Push received had no ID/data/uri or was incorrectly formatted, ignoring...");
             return;
@@ -65,7 +70,8 @@ public class FirebaseMessageHandler {
                 remoteMessage.getSentTime(),
                 uri,
                 runBackgroundHandler,
-                pictureUrl
+                pictureUrl,
+                buttons
         );
 
         Intent intent = new Intent(PushBroadcastReceiver.ACTION_PUSH_RECEIVED);

--- a/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
+++ b/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
@@ -3,7 +3,6 @@ package com.kumulos.android;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.util.Log;
 
 import com.google.firebase.messaging.RemoteMessage;
 

--- a/kumulos/src/main/java/com/kumulos/android/Kumulos.java
+++ b/kumulos/src/main/java/com/kumulos/android/Kumulos.java
@@ -63,6 +63,8 @@ public final class Kumulos {
     /** package */ static ExecutorService executorService;
     private static final Object userIdLocker = new Object();
 
+    static PushActionHandlerInterface pushActionHandler = null;
+
     /** package */ static class BaseCallback {
         public void onFailure(Exception e) {
             e.printStackTrace();
@@ -591,6 +593,14 @@ public final class Kumulos {
         }
 
         return body.build();
+    }
+
+    /**
+     * Allows setting the handler you want to use for push action buttons
+     * @param handler
+     */
+    public static void setPushActionHandler(PushActionHandlerInterface handler) {
+        pushActionHandler = handler;
     }
 
     /**

--- a/kumulos/src/main/java/com/kumulos/android/PushActionHandlerInterface.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushActionHandlerInterface.java
@@ -1,0 +1,13 @@
+package com.kumulos.android;
+
+import android.content.Context;
+
+public interface PushActionHandlerInterface {
+    /**
+     * Override to change the behaviour of push action button deep link. Default none
+     *
+     * @param buttonIdentifier identifier of the button clicked
+     * @return
+     */
+    void handle(Context context, String buttonIdentifier);
+}

--- a/kumulos/src/main/java/com/kumulos/android/PushActionHandlerInterface.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushActionHandlerInterface.java
@@ -9,5 +9,5 @@ public interface PushActionHandlerInterface {
      * @param buttonIdentifier identifier of the button clicked
      * @return
      */
-    void handle(Context context, String buttonIdentifier);
+    void handle(Context context, PushMessage pushMessage, String buttonIdentifier);
 }

--- a/kumulos/src/main/java/com/kumulos/android/PushActionHandlerInterface.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushActionHandlerInterface.java
@@ -6,8 +6,8 @@ public interface PushActionHandlerInterface {
     /**
      * Override to change the behaviour of push action button deep link. Default none
      *
-     * @param buttonIdentifier identifier of the button clicked
+     * @param actionId identifier of the button clicked
      * @return
      */
-    void handle(Context context, PushMessage pushMessage, String buttonIdentifier);
+    void handle(Context context, PushMessage pushMessage, String actionId);
 }

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -63,7 +63,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 break;
             case ACTION_BUTTON_CLICKED:
                 String buttonIdentifier = intent.getStringExtra(PushBroadcastReceiver.EXTRAS_KEY_BUTTON_ID);
-                this.handleButtonClick(context, buttonIdentifier);
+                this.handleButtonClick(context, pushMessage, buttonIdentifier);
                 break;
 
         }
@@ -75,9 +75,9 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
      * @param context
      * @param buttonIdentifier
      */
-    protected void handleButtonClick(Context context, String buttonIdentifier) {
+    protected void handleButtonClick(Context context, PushMessage pushMessage, String buttonIdentifier) {
         if (Kumulos.pushActionHandler != null){
-            Kumulos.pushActionHandler.handle(context, buttonIdentifier);
+            Kumulos.pushActionHandler.handle(context, pushMessage, buttonIdentifier);
         }
     }
 
@@ -332,15 +332,16 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
             try{
                 JSONObject button = buttons.getJSONObject(i);
                 String label = button.getString("text");
-                String buttonId = button.getInt("id") + "";//TODO: string ids
+                String buttonId = button.getString("id");
 
                 Intent clickIntent = new Intent(ACTION_BUTTON_CLICKED);
+                clickIntent.putExtra(PushMessage.EXTRAS_KEY, pushMessage);
                 clickIntent.putExtra(PushBroadcastReceiver.EXTRAS_KEY_BUTTON_ID, buttonId);
                 clickIntent.setPackage(context.getPackageName());
 
                 PendingIntent pendingClickIntent = PendingIntent.getBroadcast(
                         context,
-                        ((int) pushMessage.getTimeSent()) + (i+1),//TODO: properly unique request code?
+                        ((int) pushMessage.getTimeSent()) + (i+1),
                         clickIntent,
                         PendingIntent.FLAG_ONE_SHOT);
 

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -346,11 +346,10 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                         PendingIntent.FLAG_ONE_SHOT);
 
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M){
-                    notificationBuilder.addAction(R.drawable.kumulos_ic_stat_notifications, label, pendingClickIntent);
+                    notificationBuilder.addAction(0, label, pendingClickIntent);
                 }
                 else {
-                    Icon buttonIcon = Icon.createWithResource(context, R.drawable.kumulos_ic_stat_notifications);
-                    Notification.Action action = new Notification.Action.Builder(buttonIcon, label, pendingClickIntent).build();
+                    Notification.Action action = new Notification.Action.Builder(null, label, pendingClickIntent).build();
 
                     notificationBuilder.addAction(action);
                 }

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -36,7 +36,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
     public static final String ACTION_PUSH_RECEIVED = "com.kumulos.push.RECEIVED";
     public static final String ACTION_PUSH_OPENED = "com.kumulos.push.OPENED";
-    public static final String ACTION_BUTTON_CLICKED = "com.kumulos.push.BUTTONCLICKED";
+    public static final String ACTION_BUTTON_CLICKED = "com.kumulos.push.BUTTON_CLICKED";
 
     static final String EXTRAS_KEY_TICKLE_ID = "com.kumulos.inapp.tickle.id";
     static final String EXTRAS_KEY_BUTTON_ID = "com.kumulos.push.message.button.id";
@@ -71,15 +71,15 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
     }
 
     /**
-     * Handles handles action button clicks
+     * Handles action button clicks
      *
      * @param context
      * @param buttonIdentifier
      */
     protected void handleButtonClick(Context context, String buttonIdentifier) {
-
-
-        Log.d("vlad", buttonIdentifier);
+        if (Kumulos.pushActionHandler != null){
+            Kumulos.pushActionHandler.handle(context, buttonIdentifier);
+        }
     }
 
     /**
@@ -326,7 +326,6 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
             return null;
         }
-
         return notificationBuilder.build();
     }
 
@@ -354,7 +353,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 }
                 else {//[23,...)
                     Icon buttonIcon = Icon.createWithResource(context, R.drawable.kumulos_ic_stat_notifications);
-                    Notification.Action action = new Notification.Action.Builder(buttonIcon, label, pendingClickIntent).build();//TODO: other options on builder?
+                    Notification.Action action = new Notification.Action.Builder(buttonIcon, label, pendingClickIntent).build();
 
                     notificationBuilder.addAction(action);
 

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -23,7 +23,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import android.util.DisplayMetrics;
-import android.util.Log;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -308,8 +307,6 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 .setAutoCancel(true)
                 .setContentIntent(pendingOpenIntent);
 
-
-        //no pictures, no buttons
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
             return notificationBuilder.getNotification();
         }
@@ -338,7 +335,6 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 String buttonId = button.getInt("id") + "";//TODO: string ids
 
                 Intent clickIntent = new Intent(ACTION_BUTTON_CLICKED);
-                clickIntent.putExtra(PushMessage.EXTRAS_KEY, pushMessage);
                 clickIntent.putExtra(PushBroadcastReceiver.EXTRAS_KEY_BUTTON_ID, buttonId);
                 clickIntent.setPackage(context.getPackageName());
 
@@ -348,15 +344,14 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                         clickIntent,
                         PendingIntent.FLAG_ONE_SHOT);
 
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M){//[16,23)
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M){
                     notificationBuilder.addAction(R.drawable.kumulos_ic_stat_notifications, label, pendingClickIntent);
                 }
-                else {//[23,...)
+                else {
                     Icon buttonIcon = Icon.createWithResource(context, R.drawable.kumulos_ic_stat_notifications);
                     Notification.Action action = new Notification.Action.Builder(buttonIcon, label, pendingClickIntent).build();
 
                     notificationBuilder.addAction(action);
-
                 }
             }
             catch(JSONException e){

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -75,7 +75,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
      * @param context
      * @param buttonIdentifier
      */
-    protected void handleButtonClick(Context context, PushMessage pushMessage, String buttonIdentifier) {
+    private void handleButtonClick(Context context, PushMessage pushMessage, String buttonIdentifier) {
         if (Kumulos.pushActionHandler != null){
             Kumulos.pushActionHandler.handle(context, pushMessage, buttonIdentifier);
         }

--- a/kumulos/src/main/java/com/kumulos/android/PushMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushMessage.java
@@ -5,7 +5,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
-import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/kumulos/src/main/java/com/kumulos/android/PushMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushMessage.java
@@ -5,7 +5,9 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
+import android.util.Log;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -27,8 +29,9 @@ public final class PushMessage implements Parcelable {
     private boolean runBackgroundHandler;
     private int tickleId;
     private String pictureUrl;
+    private JSONArray buttons;
 
-    /** package */ PushMessage(int id, @Nullable String title, @Nullable String message, JSONObject data, long timeSent, @Nullable Uri url, boolean runBackgroundHandler, @Nullable String pictureUrl) {
+    /** package */ PushMessage(int id, @Nullable String title, @Nullable String message, JSONObject data, long timeSent, @Nullable Uri url, boolean runBackgroundHandler, @Nullable String pictureUrl, @Nullable JSONArray buttons) {
         this.id = id;
         this.title = title;
         this.message = message;
@@ -38,6 +41,7 @@ public final class PushMessage implements Parcelable {
         this.url = url;
         this.runBackgroundHandler = runBackgroundHandler;
         this.pictureUrl = pictureUrl;
+        this.buttons = buttons;
     }
 
     private PushMessage(Parcel in) {
@@ -62,6 +66,15 @@ public final class PushMessage implements Parcelable {
         }
         tickleId = in.readInt();
         pictureUrl = in.readString();
+
+        String buttonsString = in.readString();
+        if (null != dataString) {
+            try {
+                buttons = new JSONArray(buttonsString);
+            } catch (JSONException e) {
+                buttons = null;
+            }
+        }
     }
 
     private Integer getTickleId(JSONObject data){
@@ -107,6 +120,7 @@ public final class PushMessage implements Parcelable {
     public void writeToParcel(Parcel dest, int flags) {
         String dataString = (data != null) ? data.toString() : null;
         String urlString = (url != null) ? url.toString() : null;
+        String buttonsString = (buttons != null) ? buttons.toString() : null;
 
         dest.writeInt(id);
         dest.writeString(title);
@@ -117,6 +131,7 @@ public final class PushMessage implements Parcelable {
         dest.writeString(urlString);
         dest.writeInt(tickleId);
         dest.writeString(pictureUrl);
+        dest.writeString(buttonsString);
     }
 
     public int getId() {
@@ -160,5 +175,10 @@ public final class PushMessage implements Parcelable {
     @Nullable
     public String getPictureUrl(){
         return this.pictureUrl;
+    }
+
+    @Nullable
+    public JSONArray getButtons(){
+        return this.buttons;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/PushMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushMessage.java
@@ -67,7 +67,7 @@ public final class PushMessage implements Parcelable {
         pictureUrl = in.readString();
 
         String buttonsString = in.readString();
-        if (null != dataString) {
+        if (null != buttonsString) {
             try {
                 buttons = new JSONArray(buttonsString);
             } catch (JSONException e) {


### PR DESCRIPTION
### Description of Changes

In order to support push action buttons need to read optional "k.buttons" key from data. For each button add action to the NotificationBuilder. When button clicked pending intent with `ACTION_BUTTON_CLICKED` is dispatched. This intent is caught by the same `PushBroadcastReceiver`, which in turns calls `pushActionHandler.handle()` if set by an app.

In order for it to work need to 
1) call `Kumulos.setPushActionHandler(new MyPushActionHandler());` (e.g. in App.onCreate)
2) add `<action android:name="com.kumulos.push.BUTTON_CLICKED" />` to PushBroadcastReceiver's intent filters in App's manifest

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
