### PR TITLE
Clean up in-app overlay when app resumes after handling URL buttons

### DIFF
--- a/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
@@ -371,7 +371,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
         @Override
         public void onActivityResumed(Activity activity) {
-            currentActivityRef = new WeakReference<Activity>(activity);
+            currentActivityRef = new WeakReference<>(activity);
 
             Integer tickleId = this.getTickleId(activity);
             if ((isBackground() || tickleId != null) && KumulosInApp.isInAppEnabled()) {

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -49,6 +49,7 @@ class InAppMessagePresenter {
     private static int prevStatusBarColor;
     private static boolean prevFlagTranslucentStatus;
     private static boolean prevFlagDrawsSystemBarBackgrounds;
+    private static boolean presentationPendingOnResume = false;
 
     static synchronized void presentMessages(List<InAppMessage> itemsToPresent, List<Integer> tickleIds){
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
@@ -83,6 +84,10 @@ class InAppMessagePresenter {
         }
 
         maybeRefreshFirstMessageInQueue(oldQueue);
+
+        if (presentationPendingOnResume) {
+            presentMessageToClient();
+        }
     }
 
     private static void maybeRefreshFirstMessageInQueue(List<InAppMessage> oldQueue){
@@ -134,8 +139,12 @@ class InAppMessagePresenter {
     private static void presentMessageToClient(){
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
         if (currentActivity == null){
+            presentationPendingOnResume = true;
+
             return;
         }
+
+        presentationPendingOnResume = false;
 
         if (messageQueue.isEmpty()){
             closeDialog(currentActivity);

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -51,17 +51,21 @@ class InAppMessagePresenter {
     private static boolean prevFlagDrawsSystemBarBackgrounds;
 
     static synchronized void presentMessages(List<InAppMessage> itemsToPresent, List<Integer> tickleIds){
-        if (itemsToPresent.isEmpty()){
-            return;
-        }
-
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
 
         if (currentActivity == null) {
             return;
         }
 
-        List<InAppMessage> oldQueue = new ArrayList<InAppMessage>(messageQueue);
+        if (itemsToPresent.isEmpty()) {
+            if (messageQueue.isEmpty()) {
+                maybeCloseDialog(currentActivity);
+            }
+
+            return;
+        }
+
+        List<InAppMessage> oldQueue = new ArrayList<>(messageQueue);
 
         addMessagesToQueue(itemsToPresent);
         moveTicklesToFront(tickleIds);


### PR DESCRIPTION
### Description of Changes

When a button action for in-app messages includes opening a URL, the current activity is paused
which makes the ForegroundStateWatcher return null in presentMessagesToClient.

This in turn has the effect that the last message in the queue is not cleaning up the view when
the user navigates back to the app, and it appears the app is 'frozen' because the in-app overlay
is still on top of the screen.

The fix checks if the queue is empty in the public presentMessages routine, which is called when
the app resumes any activity, and then cleans up the view if there is nothing more to present.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [ ] ~~README.md~~ will release as part of 8.4.0

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
