### PR TITLE
Associating user results in an empty inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:8.4.1'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:8.4.1'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:8.4.2'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:8.4.2'
 }
 ```
 

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -276,8 +276,7 @@ class InAppContract {
 
             return itemsToPresent;
         }
-
-
+        
         private List<ContentValues> assembleRows() throws ParseException{
             List<ContentValues> rows = new ArrayList<>();
 
@@ -290,7 +289,10 @@ class InAppContract {
                     values.put(InAppMessageTable.COL_DISMISSED_AT, dbDateFormat.format(message.getDismissedAt()));
                 }
 
-                values.put(InAppMessageTable.COL_EXPIRES_AT, dbDateFormat.format(message.getExpiresAt()));
+                Date expiresAt = message.getExpiresAt();
+                if (expiresAt != null) {
+                    values.put(InAppMessageTable.COL_EXPIRES_AT, dbDateFormat.format(expiresAt));
+                }
                 values.put(InAppMessageTable.COL_UPDATED_AT, dbDateFormat.format(message.getUpdatedAt()));
                 values.put(InAppMessageTable.COL_PRESENTED_WHEN, message.getPresentedWhen());
 

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -137,6 +137,8 @@ public class KumulosInApp {
         }
         else if (strategy == KumulosConfig.InAppConsentStrategy.AUTO_ENROLL){
             updateRemoteInAppEnablementFlag(true);
+
+            fetchMessages();
         }
         else if (strategy == null){
             updateRemoteInAppEnablementFlag(false);
@@ -148,14 +150,18 @@ public class KumulosInApp {
         if (enabled){
             its.startPeriodicFetches(application);
 
-            new Thread(new Runnable() {
-                public void run() {
-                    InAppMessageService.fetch(KumulosInApp.application, true);
-                }
-            }).start();
+            fetchMessages();
         }
         else {
             its.cancelPeriodicFetches(application);
         }
+    }
+
+    private static void fetchMessages(){
+        new Thread(new Runnable() {
+            public void run() {
+                InAppMessageService.fetch(KumulosInApp.application, true);
+            }
+        }).start();
     }
 }


### PR DESCRIPTION
### Description of Changes

Problem: user association results in an empty inbox
Solution:
1) do extra sync after user is associated
2) missing sync only explains empty inbox partly -- it would be read when the next sync happens. The 2nd problem was that messages only shown in inbox don't have ttl, but the sdk didn't handle null ttl properly. So, when reading all messages for the newly associated user if there is a single message without ttl, this would result in an Exception (logged, but no crash), so, other messages wouldn't be saved.

Add extra sync and guard against null


### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
