### PR TITLE
Notification improvements: long-text, sound, time

### DIFF
--- a/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
+++ b/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
@@ -45,6 +45,7 @@ public class FirebaseMessageHandler {
         Uri uri;
         String pictureUrl = bundle.get("bicon");
         JSONArray buttons;
+        String sound = bundle.get("sound");
 
         try {
             custom = new JSONObject(customStr);
@@ -70,7 +71,8 @@ public class FirebaseMessageHandler {
                 uri,
                 runBackgroundHandler,
                 pictureUrl,
-                buttons
+                buttons,
+                sound
         );
 
         Intent intent = new Intent(PushBroadcastReceiver.ACTION_PUSH_RECEIVED);

--- a/kumulos/src/main/java/com/kumulos/android/InAppRequestService.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppRequestService.java
@@ -1,6 +1,7 @@
 package com.kumulos.android;
 
 import android.content.Context;
+import android.net.Uri;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -39,7 +40,8 @@ class InAppRequestService {
             sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
             params= "?after="+ sdf.format(lastSyncTime);
         }
-        String url = Kumulos.PUSH_BASE_URL + "/v1/users/"+userIdentifier+"/messages"+params;
+        String encodedIdentifier = Uri.encode(userIdentifier);
+        String url = Kumulos.PUSH_BASE_URL + "/v1/users/"+encodedIdentifier+"/messages"+params;
 
         final Request request = new Request.Builder()
                 .url(url)

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -170,8 +170,6 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
         }).start();
     }
 
-
-
     private int getNotificationId(PushMessage pushMessage){
         int tickleId = pushMessage.getTickleId();
         if (tickleId == -1){
@@ -359,8 +357,6 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
         }
 
         Uri sound = Uri.parse("android.resource://"+context.getPackageName()+"/raw/"+soundFileName);
-
-
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O){
             notificationBuilder.setSound(sound);
             return;

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -301,6 +301,12 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
             NotificationChannel channel = notificationManager.getNotificationChannel(DEFAULT_CHANNEL_ID);
             if (null == channel) {
+                //channelId was changed to set sound to null on existing installs. Remove old channel if still exists
+                NotificationChannel oldChannel = notificationManager.getNotificationChannel("general");
+                if (oldChannel != null){
+                    notificationManager.deleteNotificationChannel("general");
+                }
+
                 channel = new NotificationChannel(DEFAULT_CHANNEL_ID, "General", NotificationManager.IMPORTANCE_DEFAULT);
                 channel.setSound(null, null);
                 notificationManager.createNotificationChannel(channel);

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -15,8 +15,6 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.drawable.Icon;
-import android.media.AudioAttributes;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
@@ -27,7 +25,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import android.util.DisplayMetrics;
-import android.util.Log;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -372,6 +369,24 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
         NotificationChannel channel = notificationManager.getNotificationChannel(DEFAULT_CHANNEL_ID);
         //user-defined sound takes precedence
         if (channel.getSound() != null){
+            return;
+        }
+
+        int filter = notificationManager.getCurrentInterruptionFilter();
+        boolean inDnD = false;
+        switch(filter){
+            case NotificationManager.INTERRUPTION_FILTER_ALL:
+                inDnD = false;
+                break;
+            case NotificationManager.INTERRUPTION_FILTER_PRIORITY:
+                inDnD = !channel.canBypassDnd();
+                break;
+            case NotificationManager.INTERRUPTION_FILTER_UNKNOWN:
+            case NotificationManager.INTERRUPTION_FILTER_ALARMS:
+            case NotificationManager.INTERRUPTION_FILTER_NONE:
+                 inDnD = true;
+        }
+        if (inDnD){
             return;
         }
 

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import android.support.annotation.Nullable;
 
 public class PushBroadcastReceiver extends BroadcastReceiver {
     public static final String TAG = PushBroadcastReceiver.class.getName();
@@ -355,7 +356,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
         return notificationBuilder.build();
     }
 
-    private void maybeAddSound(Context context, Notification.Builder notificationBuilder, NotificationManager notificationManager, PushMessage pushMessage){
+    private void maybeAddSound(Context context, Notification.Builder notificationBuilder, @Nullable NotificationManager notificationManager, PushMessage pushMessage){
         String soundFileName = pushMessage.getSound();
 
         if (soundFileName == null){
@@ -365,6 +366,10 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
         Uri sound = Uri.parse("android.resource://"+context.getPackageName()+"/raw/"+soundFileName);
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O){
             notificationBuilder.setSound(sound);
+            return;
+        }
+
+        if (notificationManager == null){
             return;
         }
 

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -319,7 +319,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 .setContentText(pushMessage.getMessage())
                 .setAutoCancel(true)
                 .setContentIntent(pendingOpenIntent);
-
+        
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
              notificationBuilder.setShowWhen(true);
         }
@@ -327,6 +327,8 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
             return notificationBuilder.getNotification();
         }
+
+        notificationBuilder.setStyle(new Notification.BigTextStyle().bigText(pushMessage.getMessage()));
 
         JSONArray buttons = pushMessage.getButtons();
         if (buttons != null){

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -42,7 +42,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
     static final String EXTRAS_KEY_TICKLE_ID = "com.kumulos.inapp.tickle.id";
     static final String EXTRAS_KEY_BUTTON_ID = "com.kumulos.push.message.button.id";
 
-    private static final String DEFAULT_CHANNEL_ID = "generalV2";
+    private static final String DEFAULT_CHANNEL_ID = "kumulos_general";
     protected static final String KUMULOS_NOTIFICATION_TAG = "kumulos";
 
     private static final String MEDIA_RESIZER_BASE_URL = "https://i.app.delivery";

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -320,6 +320,10 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 .setAutoCancel(true)
                 .setContentIntent(pendingOpenIntent);
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+             notificationBuilder.setShowWhen(true);
+        }
+
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
             return notificationBuilder.getNotification();
         }

--- a/kumulos/src/main/java/com/kumulos/android/PushMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushMessage.java
@@ -77,10 +77,7 @@ public final class PushMessage implements Parcelable {
             }
         }
 
-        String soundStr = in.readString();
-        if (null != soundStr) {
-            sound = soundStr;
-        }
+        sound = in.readString();
     }
 
     private Integer getTickleId(JSONObject data){

--- a/kumulos/src/main/java/com/kumulos/android/PushMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushMessage.java
@@ -29,8 +29,9 @@ public final class PushMessage implements Parcelable {
     private int tickleId;
     private String pictureUrl;
     private JSONArray buttons;
+    private String sound;
 
-    /** package */ PushMessage(int id, @Nullable String title, @Nullable String message, JSONObject data, long timeSent, @Nullable Uri url, boolean runBackgroundHandler, @Nullable String pictureUrl, @Nullable JSONArray buttons) {
+    /** package */ PushMessage(int id, @Nullable String title, @Nullable String message, JSONObject data, long timeSent, @Nullable Uri url, boolean runBackgroundHandler, @Nullable String pictureUrl, @Nullable JSONArray buttons, @Nullable String sound) {
         this.id = id;
         this.title = title;
         this.message = message;
@@ -41,6 +42,7 @@ public final class PushMessage implements Parcelable {
         this.runBackgroundHandler = runBackgroundHandler;
         this.pictureUrl = pictureUrl;
         this.buttons = buttons;
+        this.sound = sound;
     }
 
     private PushMessage(Parcel in) {
@@ -73,6 +75,11 @@ public final class PushMessage implements Parcelable {
             } catch (JSONException e) {
                 buttons = null;
             }
+        }
+
+        String soundStr = in.readString();
+        if (null != soundStr) {
+            sound = soundStr;
         }
     }
 
@@ -131,6 +138,7 @@ public final class PushMessage implements Parcelable {
         dest.writeInt(tickleId);
         dest.writeString(pictureUrl);
         dest.writeString(buttonsString);
+        dest.writeString(sound);
     }
 
     public int getId() {
@@ -180,4 +188,10 @@ public final class PushMessage implements Parcelable {
     public JSONArray getButtons(){
         return this.buttons;
     }
+
+    @Nullable
+    public String getSound(){
+        return this.sound;
+    }
+
 }

--- a/kumulos/src/main/java/com/kumulos/android/PushSubscriptionManager.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushSubscriptionManager.java
@@ -43,9 +43,7 @@ public class PushSubscriptionManager {
     /**
      * Subscribes the current installation to the push channels specified by their unique identifiers.
      *
-     * Note that channels must exist prior to subscription requests.
-     *
-     * Duplicate subscription requests will be ignored.
+     * Channels that don't exist will be created.
      *
      * @param c
      * @param uuids The unique push channel identifiers to subscribe to
@@ -62,9 +60,7 @@ public class PushSubscriptionManager {
     /**
      * Subscribes the current installation to the push channels specified by their unique identifiers.
      *
-     * Note that channels must exist prior to subscription requests.
-     *
-     * Duplicate subscription requests will be ignored.
+     * Channels that don't exist will be created.
      *
      * @param c
      * @param uuids The unique push channel identifiers to subscribe to


### PR DESCRIPTION
### Description of Changes

1) show sentWhen
2) encode userIdentifier when doing in-app sync
3) display long text messages
4) Respect sound from payload. Users of the SDK should put sound file into `res/raw` and add file name without extension to the payload as in docs. On Android < O use `builder.setSound()`. On Android >= O we cannot use notification channels because cannot change sound after channel is created. So, instead change channel id to create a new channel (to deal with existing installs), disable channel sound, 'manually' play provided sound if user hasn't updated channel sound
5) update description of `channel.subscribe()`

Readme will be updated in the following MR

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [ ] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
