### PR TITLE
Tweak notification sounds and vibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:10.0.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:10.0.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:10.1.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:10.1.0'
 }
 ```
 

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -44,7 +44,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
     static final String EXTRAS_KEY_TICKLE_ID = "com.kumulos.inapp.tickle.id";
     static final String EXTRAS_KEY_BUTTON_ID = "com.kumulos.push.message.button.id";
 
-    private static final String DEFAULT_CHANNEL_ID_v3 = "kumulos_general_v3";
+    private static final String DEFAULT_CHANNEL_ID = "kumulos_general_v3";
     protected static final String KUMULOS_NOTIFICATION_TAG = "kumulos";
 
     private static final String MEDIA_RESIZER_BASE_URL = "https://i.app.delivery";
@@ -296,17 +296,17 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 return null;
             }
 
-            NotificationChannel channel = notificationManager.getNotificationChannel(DEFAULT_CHANNEL_ID_v3);
+            NotificationChannel channel = notificationManager.getNotificationChannel(DEFAULT_CHANNEL_ID);
             if (null == channel) {
                 this.clearOldChannels(notificationManager);
 
-                channel = new NotificationChannel(DEFAULT_CHANNEL_ID_v3, "General", NotificationManager.IMPORTANCE_DEFAULT);
+                channel = new NotificationChannel(DEFAULT_CHANNEL_ID, "General", NotificationManager.IMPORTANCE_DEFAULT);
                 channel.setSound(null, null);
                 channel.setVibrationPattern(new long[]{0, 250, 250, 250});
                 notificationManager.createNotificationChannel(channel);
             }
 
-            notificationBuilder = new Notification.Builder(context, DEFAULT_CHANNEL_ID_v3);
+            notificationBuilder = new Notification.Builder(context, DEFAULT_CHANNEL_ID);
         }
         else {
             notificationBuilder = new Notification.Builder(context);
@@ -375,7 +375,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
             return;
         }
 
-        NotificationChannel channel = notificationManager.getNotificationChannel(DEFAULT_CHANNEL_ID_v3);
+        NotificationChannel channel = notificationManager.getNotificationChannel(DEFAULT_CHANNEL_ID);
         if (channel.getSound() != null){
             return;
         }

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -44,7 +44,6 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
     static final String EXTRAS_KEY_TICKLE_ID = "com.kumulos.inapp.tickle.id";
     static final String EXTRAS_KEY_BUTTON_ID = "com.kumulos.push.message.button.id";
 
-    private static final String DEFAULT_CHANNEL_ID = "kumulos_general";
     private static final String DEFAULT_CHANNEL_ID_v3 = "kumulos_general_v3";
     protected static final String KUMULOS_NOTIFICATION_TAG = "kumulos";
 
@@ -349,14 +348,13 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
     @TargetApi(android.os.Build.VERSION_CODES.O)
     private void clearOldChannels(NotificationManager notificationManager){
         //Initial setup of channels changed multiple times. Remove old channels
-        NotificationChannel oldChannel = notificationManager.getNotificationChannel("general");
-        if (oldChannel != null){
-            notificationManager.deleteNotificationChannel("general");
-        }
+        String[] oldChannelIds = {"general","kumulos_general"};
 
-        NotificationChannel oldChannel2 = notificationManager.getNotificationChannel(DEFAULT_CHANNEL_ID);
-        if (oldChannel2 != null){
-            notificationManager.deleteNotificationChannel(DEFAULT_CHANNEL_ID);
+        for(String channelId : oldChannelIds){
+            NotificationChannel oldChannel = notificationManager.getNotificationChannel(channelId);
+            if (oldChannel != null){
+                notificationManager.deleteNotificationChannel(channelId);
+            }
         }
     }
 

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -21,7 +21,6 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.util.DisplayMetrics;
-import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONException;


### PR DESCRIPTION
### Description of Changes

1) Turn on vibration by default (with default vibration pattern)
2) Play default notification sound. 

**Notification sound rules are:**

1) When created channel does not have sound
2) Sdk cannot change channel sound, but user can. User cannot set sound to none/null, but can control silence via importance.
3) If channel sound set, play it (ignore custom sound / default sound)
4) If no channel sound, If channel importance <= LOW, leave without sounds
5) If no channel sound, if importance > LOW and no DnD: play default sound
6) If no channel sound, if importance > LOW and no DnD and custom sound: play custom sound

This changes previous behaviour: custom sound is not played if user set low importance (by selecting `Silent` vs `Alerting`). Notifications with importance > LOW play default sound


### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
