### PR TITLE
Fix for in-app messages containing videos randomly closing sometimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ android {
 dependencies {
     // Kumulos debug & release libraries
 
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.1.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.1.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.1.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.1.1'
 
 }
 ```

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -484,7 +484,19 @@ class InAppMessagePresenter {
                         @SuppressWarnings("deprecation")
                         @Override
                         public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
-                            Kumulos.log(TAG, "Error code: "+errorCode+". "+description);
+                            Kumulos.log(TAG, "Error code: " + errorCode + ". " + description + " " + failingUrl);
+
+                            String extension = failingUrl.substring(failingUrl.length() - 4);
+                            boolean isVideo = extension.matches(".mp4|.m4a|.m4p|.m4b|.m4r|.m4v");
+                            if (errorCode == -1 && "net::ERR_FAILED".equals(description) && isVideo) {
+                                // This is a workaround for a bug in the WebView.
+                                // See these chromium issues for more context:
+                                // https://bugs.chromium.org/p/chromium/issues/detail?id=1023678
+                                // https://bugs.chromium.org/p/chromium/issues/detail?id=1050635
+
+                                //We encountered the issue only with some (and not other) videos, but possibly not limited to other file types
+                                return;
+                            }
 
                             closeDialog(currentActivity);
                         }


### PR DESCRIPTION
### Description of Changes

Due to a bug in specific versions of Chromium, the onReceivedError handler can be invoked
spuriously for video resources.

Work around the issue by testing the specific failure conditions, and failing resource and
don't close the in-app dialog under those conditions.

See:

- https://bugs.chromium.org/p/chromium/issues/detail?id=1023678
- https://bugs.chromium.org/p/chromium/issues/detail?id=1050635

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
