### PR TITLE
Don't process deep links when activity recreated

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.3.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.3.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.3.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.3.1'
 }
 ```
 

--- a/kumulos/src/main/java/com/kumulos/android/Kumulos.java
+++ b/kumulos/src/main/java/com/kumulos/android/Kumulos.java
@@ -8,6 +8,7 @@ import android.content.SharedPreferences;
 import android.location.Location;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Debug;
 import android.os.Looper;
 import android.text.TextUtils;
@@ -597,6 +598,13 @@ public final class Kumulos {
     //==============================================================================================
     //-- DEFERRED DEEP LINKING
 
+    public static void seeIntent(Context context, Intent intent, @Nullable Bundle savedInstanceState) {
+        if (savedInstanceState != null){
+            return;
+        }
+
+        Kumulos.seeIntent(context, intent);
+    }
 
     public static void seeIntent(Context context, Intent intent) {
         String action = intent.getAction();


### PR DESCRIPTION
### Description of Changes

When app is collapsed, the app process may get killed if phone is low on memory. If app is opened again, the latest activity is recreated. The activity gets same intent as the one that opened it initially. This means that if the app was opened by clicking a deep link, collapsing and expanding will result in the deep link / handler being processed again. 

Dont process deep links when activity recreated

Integration should be updated to 

```language-java
@Override
protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        Kumulos.seeIntent(this, getIntent(), savedInstanceState);
}
```
### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
