### PR TITLE
Guard rare in-app NullPointerException

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.4.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.4.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.4.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.4.1'
 }
 ```
 

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -47,7 +47,7 @@ class InAppMessagePresenter {
     private static final String HOST_MESSAGE_TYPE_SET_NOTCH_INSETS = "SET_NOTCH_INSETS";
     private static final String IN_APP_RENDERER_URL = "https://iar.app.delivery";
 
-    private static List<InAppMessage> messageQueue = new ArrayList<>();
+    private static final List<InAppMessage> messageQueue = new ArrayList<>();
     @SuppressLint("StaticFieldLeak")
     private static WebView wv = null;
     private static Dialog dialog = null;
@@ -284,15 +284,23 @@ class InAppMessagePresenter {
     }
 
     private static void setSpinnerVisibility(int visibility){
+        if (wv == null){
+            return;
+        }
         wv.post(new Runnable() {
             @Override
             public void run() {
-                spinner.setVisibility(visibility);
+                if (spinner != null){
+                    spinner.setVisibility(visibility);
+                }
             }
         });
     }
 
     private static void sendToClient(String type, JSONObject data){
+        if (wv == null){
+            return;
+        }
         wv.post(new Runnable() {
             @Override
             public void run() {
@@ -471,7 +479,7 @@ class InAppMessagePresenter {
                         @Override
                         public void onPageStarted(WebView view, String url, Bitmap favicon) {
                             super.onPageStarted(view, url, favicon);
-                            spinner.setVisibility(View.VISIBLE);
+                            InAppMessagePresenter.setSpinnerVisibility(View.VISIBLE);
                         }
 
                         @Override


### PR DESCRIPTION
### Description of Changes

`spinner.setVisibility(...)` fails with a NullPointerException. Spinner is stored as a static variable, which could have been garbage collected. Add null checks

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
