### PR TITLE
In-app: mark as read

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.4.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.4.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.4.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.4.1'
 }
 ```
 

--- a/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
@@ -44,6 +44,7 @@ import androidx.work.WorkManager;
     static final String EVENT_TYPE_MESSAGE_DISMISSED = "k.message.dismissed";
     static final String EVENT_TYPE_MESSAGE_OPENED = "k.message.opened";
     static final String EVENT_TYPE_MESSAGE_DELIVERED = "k.message.delivered";
+    static final String EVENT_TYPE_MESSAGE_READ = "k.message.read";
     static final String EVENT_TYPE_ENTERED_BEACON_PROXIMITY = "k.engage.beaconEnteredProximity";
     static final String EVENT_TYPE_LOCATION_UPDATED = "k.engage.locationUpdated";
     static final String MESSAGE_DELETED_FROM_INBOX = "k.message.inbox.deleted";

--- a/kumulos/src/main/java/com/kumulos/android/InAppDbHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppDbHelper.java
@@ -9,7 +9,7 @@ import com.kumulos.android.InAppContract.InAppMessageTable;
 
 class InAppDbHelper extends SQLiteOpenHelper {
     private static final String DB_NAME = "k_in_app.db";
-    private static final int DB_VERSION = 2;
+    private static final int DB_VERSION = 3;
 
     private static final String SQL_CREATE_IN_APP_MESSAGES
             = "CREATE TABLE " + InAppMessageTable.TABLE_NAME + "("
@@ -23,7 +23,8 @@ class InAppDbHelper extends SQLiteOpenHelper {
             + InAppMessageTable.COL_INBOX_TO + " DATETIME,"
             + InAppMessageTable.COL_DISMISSED_AT + " DATETIME,"
             + InAppMessageTable.COL_UPDATED_AT + " DATETIME NOT NULL,"
-            + InAppMessageTable.COL_EXPIRES_AT + " DATETIME)";
+            + InAppMessageTable.COL_EXPIRES_AT + " DATETIME,"
+            + InAppMessageTable.COL_READ_AT + " DATETIME)";
 
     InAppDbHelper(Context context) {
         super(context, DB_NAME, null, DB_VERSION);
@@ -42,16 +43,27 @@ class InAppDbHelper extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        switch(newVersion) {
-            case 2:
-                this.upgradeToVersion2(db);
-                break;
-            default:
-                throw new IllegalStateException("onUpgrade() with unknown newVersion " + newVersion);
+
+        for (int i = oldVersion+1; i <= newVersion; ++i) {
+            switch(i) {
+                case 2:
+                    this.upgradeToVersion2(db);
+                    break;
+                case 3:
+                    this.upgradeToVersion3(db);
+                    break;
+                default:
+                    throw new IllegalStateException("onUpgrade() with unknown newVersion " + newVersion);
+            }
         }
+
     }
 
     private void upgradeToVersion2(SQLiteDatabase db){
         db.execSQL("ALTER TABLE " + InAppMessageTable.TABLE_NAME + " ADD COLUMN " + InAppMessageTable.COL_EXPIRES_AT + " DATETIME;");
+    }
+
+    private void upgradeToVersion3(SQLiteDatabase db){
+        db.execSQL("ALTER TABLE " + InAppMessageTable.TABLE_NAME + " ADD COLUMN " + InAppMessageTable.COL_READ_AT + " DATETIME;");
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
@@ -17,6 +17,8 @@ public class InAppInboxItem {
     private Date availableTo;
     @Nullable
     private Date dismissedAt;
+    @Nullable
+    private Date readAt;
 
     public int getId() {
         return id;
@@ -67,5 +69,13 @@ public class InAppInboxItem {
 
     void setDismissedAt(@Nullable Date dismissedAt) {
         this.dismissedAt = dismissedAt;
+    }
+
+    public boolean isRead() {
+        return readAt != null;
+    }
+
+    void setReadAt(@Nullable Date readAt) {
+        this.readAt = readAt;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
@@ -29,6 +29,8 @@ class InAppMessage {
     private Date expiresAt = null;
     @Nullable
     private Date inboxDeletedAt;
+    @Nullable
+    private Date readAt;
 
     InAppMessage(){}
 
@@ -54,6 +56,10 @@ class InAppMessage {
 
         if (!obj.isNull("inboxDeletedAt")) {
             this.inboxDeletedAt = sdf.parse(obj.getString("inboxDeletedAt"));
+        }
+
+        if (!obj.isNull("readAt")) {
+            this.readAt = sdf.parse(obj.getString("readAt"));
         }
     }
 
@@ -115,5 +121,10 @@ class InAppMessage {
     @Nullable
     Date getInboxDeletedAt() {
         return inboxDeletedAt;
+    }
+
+    @Nullable
+    Date getReadAt() {
+        return readAt;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -47,7 +47,7 @@ class InAppMessagePresenter {
     private static final String HOST_MESSAGE_TYPE_SET_NOTCH_INSETS = "SET_NOTCH_INSETS";
     private static final String IN_APP_RENDERER_URL = "https://iar.app.delivery";
 
-    private static List<InAppMessage> messageQueue = new ArrayList<>();
+    private static final List<InAppMessage> messageQueue = new ArrayList<>();
     @SuppressLint("StaticFieldLeak")
     private static WebView wv = null;
     private static Dialog dialog = null;
@@ -284,15 +284,23 @@ class InAppMessagePresenter {
     }
 
     private static void setSpinnerVisibility(int visibility){
+        if (wv == null){
+            return;
+        }
         wv.post(new Runnable() {
             @Override
             public void run() {
-                spinner.setVisibility(visibility);
+                if (spinner != null){
+                    spinner.setVisibility(visibility);
+                }
             }
         });
     }
 
     private static void sendToClient(String type, JSONObject data){
+        if (wv == null){
+            return;
+        }
         wv.post(new Runnable() {
             @Override
             public void run() {
@@ -471,7 +479,7 @@ class InAppMessagePresenter {
                         @Override
                         public void onPageStarted(WebView view, String url, Bitmap favicon) {
                             super.onPageStarted(view, url, favicon);
-                            spinner.setVisibility(View.VISIBLE);
+                            InAppMessagePresenter.setSpinnerVisibility(View.VISIBLE);
                         }
 
                         @Override

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -45,6 +45,14 @@ public class KumulosInApp {
         return InAppMessageService.deleteMessageFromInbox(context, item.getId());
     }
 
+    public static boolean markAsRead(Context context, InAppInboxItem item){
+        return InAppMessageService.markInboxItemRead(context, item.getId());
+    }
+
+//    public static boolean markAllInboxItemsAsRead(Context context){
+//        return InAppMessageService.deleteMessageFromInbox(context);
+//    }
+
     /**
      * Used to update in-app consent when enablement strategy is EXPLICIT_BY_USER
      *


### PR DESCRIPTION
### Description of Changes

New message property 'read'. The meaning of ‘message read’ is “User has seen the message, but not necessarily opened it”. Mark message as read when
1) message opened
2) inbox item deleted
3) Inbox item explicitly marked by user as read. For this expose 2 new public methods: `markAsRead(Context context, InAppInboxItem item)` and `markAllInboxItemsAsRead(Context context)`

### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [ ] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
