### PR TITLE
In-app: mark as read

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.4.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.4.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.4.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.4.1'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.4.1'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.4.1'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.5.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.5.0'
 }
 ```
 

--- a/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
@@ -44,6 +44,7 @@ import androidx.work.WorkManager;
     static final String EVENT_TYPE_MESSAGE_DISMISSED = "k.message.dismissed";
     static final String EVENT_TYPE_MESSAGE_OPENED = "k.message.opened";
     static final String EVENT_TYPE_MESSAGE_DELIVERED = "k.message.delivered";
+    static final String EVENT_TYPE_MESSAGE_READ = "k.message.read";
     static final String EVENT_TYPE_ENTERED_BEACON_PROXIMITY = "k.engage.beaconEnteredProximity";
     static final String EVENT_TYPE_LOCATION_UPDATED = "k.engage.locationUpdated";
     static final String MESSAGE_DELETED_FROM_INBOX = "k.message.inbox.deleted";

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -6,7 +6,6 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.util.Pair;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -24,7 +23,8 @@ import static android.database.sqlite.SQLiteDatabase.CONFLICT_IGNORE;
 
 class InAppContract {
 
-    private InAppContract() {}
+    private InAppContract() {
+    }
 
     static class InAppMessageTable {
         static final String TABLE_NAME = "in_app_messages";
@@ -45,8 +45,10 @@ class InAppContract {
 
     private static SimpleDateFormat dbDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
     private static SimpleDateFormat incomingDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
+    private static final String SORT_ORDER = InAppMessageTable.COL_SENT_AT + " DESC, " + InAppMessageTable.COL_UPDATED_AT + " DESC, " + InAppMessageTable.COL_ID + " DESC";
+    private static final Integer STORED_IN_APP_LIMIT = 50;
 
-    static{
+    static {
         dbDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
@@ -64,11 +66,10 @@ class InAppContract {
             try {
                 SQLiteDatabase db = dbHelper.getWritableDatabase();
 
-                db.execSQL("delete from "+ InAppMessageTable.TABLE_NAME);
+                db.execSQL("delete from " + InAppMessageTable.TABLE_NAME);
 
                 dbHelper.close();
-            }
-            catch (SQLiteException e) {
+            } catch (SQLiteException e) {
                 Kumulos.log(TAG, "Failed clearing in-app db ");
                 e.printStackTrace();
             }
@@ -92,24 +93,23 @@ class InAppContract {
             try {
                 SQLiteDatabase db = dbHelper.getWritableDatabase();
                 String datetime = dbDateFormat.format(mInAppMessage.getDismissedAt());
-                String sql = "UPDATE "+InAppMessageTable.TABLE_NAME
-                        +" SET "+InAppMessageTable.COL_DISMISSED_AT+" = ?, "+InAppMessageTable.COL_READ_AT+" = IFNULL(readAt, ?)"
-                        +" WHERE "+InAppMessageTable.COL_ID+" = ?;";
+                String sql = "UPDATE " + InAppMessageTable.TABLE_NAME
+                        + " SET " + InAppMessageTable.COL_DISMISSED_AT + " = ?, " + InAppMessageTable.COL_READ_AT + " = IFNULL(readAt, ?)"
+                        + " WHERE " + InAppMessageTable.COL_ID + " = ?;";
 
-                Cursor c = db.rawQuery(sql, new String[] {datetime, datetime, mInAppMessage.getInAppId()+""});
+                Cursor c = db.rawQuery(sql, new String[]{datetime, datetime, mInAppMessage.getInAppId() + ""});
                 c.moveToFirst();
                 c.close();
 
                 dbHelper.close();
-            }
-            catch (SQLiteException e) {
-                Kumulos.log(TAG, "Failed to track open for inAppID: "+ mInAppMessage.getInAppId());
+            } catch (SQLiteException e) {
+                Kumulos.log(TAG, "Failed to track open for inAppID: " + mInAppMessage.getInAppId());
                 e.printStackTrace();
             }
         }
     }
 
-    static class SaveInAppMessagesCallable implements Callable<Pair<List<InAppMessage>, List<Integer>>> {
+    static class SaveInAppMessagesCallable implements Callable<InAppSaveResult> {
 
         private static final String TAG = SaveInAppMessagesCallable.class.getName();
 
@@ -122,41 +122,40 @@ class InAppContract {
         }
 
         @Override
-        public Pair<List<InAppMessage>, List<Integer>> call() {
+        public InAppSaveResult call() {
             SQLiteOpenHelper dbHelper = new InAppDbHelper(mContext);
 
             List<InAppMessage> itemsToPresent = new ArrayList<>();
             List<Integer> deliveredIds = new ArrayList<>();
+            List<Integer> deletedIds = new ArrayList<>();
             try {
                 List<ContentValues> rows = this.assembleRows();
 
                 SQLiteDatabase db = dbHelper.getWritableDatabase();
 
                 deliveredIds = this.insertRows(db, rows);
-                this.deleteRows(db);
+                deletedIds = this.deleteRows(db);
                 itemsToPresent = this.readRows(db);
 
                 dbHelper.close();
-                Kumulos.log(TAG, "Saved messages: "+mInAppMessages.size());
-            }
-            catch (SQLiteException e) {
-                Kumulos.log(TAG, "Failed to save messages: "+mInAppMessages.size());
+                Kumulos.log(TAG, "Saved messages: " + mInAppMessages.size());
+            } catch (SQLiteException e) {
+                Kumulos.log(TAG, "Failed to save messages: " + mInAppMessages.size());
                 e.printStackTrace();
-            }
-            catch(Exception e){
+            } catch (Exception e) {
                 Kumulos.log(TAG, e.getMessage());
             }
 
-            return new Pair<>(itemsToPresent, deliveredIds);
+            return new InAppSaveResult(itemsToPresent, deliveredIds, deletedIds);
         }
 
-        private List<Integer> insertRows(SQLiteDatabase db, List<ContentValues> rows){
+        private List<Integer> insertRows(SQLiteDatabase db, List<ContentValues> rows) {
             List<Integer> deliveredIds = new ArrayList<>();
 
-            for(ContentValues row : rows){
+            for (ContentValues row : rows) {
                 int id = (int) db.insertWithOnConflict(InAppMessageTable.TABLE_NAME, null, row, CONFLICT_IGNORE);
                 if (id == -1) {
-                    db.update(InAppMessageTable.TABLE_NAME, row, InAppMessageTable.COL_ID+"=?", new String[] {""+row.getAsInteger(InAppMessageTable.COL_ID)});
+                    db.update(InAppMessageTable.TABLE_NAME, row, InAppMessageTable.COL_ID + "=?", new String[]{"" + row.getAsInteger(InAppMessageTable.COL_ID)});
                 }
                 //tracks all messages, which were received and saved/updated
                 deliveredIds.add(row.getAsInteger(InAppMessageTable.COL_ID));
@@ -165,12 +164,12 @@ class InAppContract {
             return deliveredIds;
         }
 
-        private void deleteRows(SQLiteDatabase db){
+        private List<Integer> deleteRows(SQLiteDatabase db) {
             String messageExpiredCondition = String.format("(%s IS NOT NULL AND (DATETIME(%s) <= DATETIME('now'))",
                     InAppMessageTable.COL_EXPIRES_AT,
                     InAppMessageTable.COL_EXPIRES_AT);
 
-            String noInboxAndMessageDismissed = String.format("(%s IS NULL AND %s IS NOT NULL)", InAppMessageTable.COL_INBOX_CONFIG_JSON,  InAppMessageTable.COL_DISMISSED_AT);
+            String noInboxAndMessageDismissed = String.format("(%s IS NULL AND %s IS NOT NULL)", InAppMessageTable.COL_INBOX_CONFIG_JSON, InAppMessageTable.COL_DISMISSED_AT);
             String noInboxAndMessageExpired = String.format("(%s IS NULL AND %s))", InAppMessageTable.COL_INBOX_CONFIG_JSON, messageExpiredCondition);
             String inboxExpiredAndMessageDismissedOrExpired = String.format("(%s IS NOT NULL AND (DATETIME('now') > IFNULL(%s, '3970-01-01')) AND (%s IS NOT NULL OR %s)))",
                     InAppMessageTable.COL_INBOX_CONFIG_JSON,
@@ -178,16 +177,35 @@ class InAppContract {
                     InAppMessageTable.COL_DISMISSED_AT,
                     messageExpiredCondition);
 
+            String notConditions = "(NOT " + noInboxAndMessageDismissed + " AND NOT " + noInboxAndMessageExpired + " AND NOT " + inboxExpiredAndMessageDismissedOrExpired + ")";
+            String inAppsExceedingLimitSql = "select * from (SELECT " + InAppMessageTable.COL_ID +
+                    " FROM " + InAppMessageTable.TABLE_NAME +
+                    " WHERE " + notConditions +
+                    " ORDER BY " + SORT_ORDER +
+                    " LIMIT -1 OFFSET " + STORED_IN_APP_LIMIT + ")";
 
-            String deleteSql ="DELETE FROM " + InAppMessageTable.TABLE_NAME +
-                    " WHERE "+
+            String readSql = "SELECT inAppId FROM " + InAppMessageTable.TABLE_NAME +
+                    " WHERE " +
                     noInboxAndMessageDismissed +
                     " OR " +
                     noInboxAndMessageExpired +
                     " OR " +
-                    inboxExpiredAndMessageDismissedOrExpired;
+                    inboxExpiredAndMessageDismissedOrExpired +
+                    " UNION " +
+                    inAppsExceedingLimitSql;
 
-            db.execSQL(deleteSql);
+            Cursor c = db.rawQuery(readSql, new String[]{});
+            List<Integer> deletedIds = new ArrayList<>();
+            while (c.moveToNext()) {
+                deletedIds.add(c.getInt(c.getColumnIndexOrThrow(InAppMessageTable.COL_ID)));
+            }
+            c.close();
+
+            String placeholders = new String(new char[deletedIds.size() - 1]).replace("\0", "?,") + "?";
+            String deleteSql = "DELETE FROM " + InAppMessageTable.TABLE_NAME + " WHERE " + InAppMessageTable.COL_ID + " IN (" + placeholders + ")";
+            db.execSQL(deleteSql, deletedIds.toArray(new Integer[0]));
+
+            return deletedIds;
         }
 
         private List<InAppMessage> readRows(SQLiteDatabase db) {
@@ -195,12 +213,11 @@ class InAppContract {
             List<InAppMessage> itemsToPresent = new ArrayList<>();
 
             String[] projection = {InAppMessageTable.COL_ID, InAppMessageTable.COL_PRESENTED_WHEN, InAppMessageTable.COL_CONTENT_JSON};
-            String selection = InAppMessageTable.COL_DISMISSED_AT+ " IS NULL";
-            String sortOrder = InAppMessageTable.COL_SENT_AT+ " DESC, " + InAppMessageTable.COL_UPDATED_AT+ " DESC, " + InAppMessageTable.COL_ID + " DESC";
+            String selection = InAppMessageTable.COL_DISMISSED_AT + " IS NULL";
 
-            Cursor cursor = db.query(InAppMessageTable.TABLE_NAME, projection, selection, null,null,null, sortOrder);
+            Cursor cursor = db.query(InAppMessageTable.TABLE_NAME, projection, selection, null, null, null, SORT_ORDER);
 
-            while(cursor.moveToNext()) {
+            while (cursor.moveToNext()) {
                 int inAppId = cursor.getInt(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_ID));
                 String content = cursor.getString(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_CONTENT_JSON));
                 String presentedWhen = cursor.getString(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_PRESENTED_WHEN));
@@ -208,10 +225,9 @@ class InAppContract {
                 m.setInAppId(inAppId);
                 m.setPresentedWhen(presentedWhen);
 
-                try{
+                try {
                     m.setContent(new JSONObject(content));
-                }
-                catch(JSONException e) {
+                } catch (JSONException e) {
                     Kumulos.log(TAG, e.getMessage());
                     continue;
                 }
@@ -223,18 +239,18 @@ class InAppContract {
 
             return itemsToPresent;
         }
-        
-        private List<ContentValues> assembleRows() throws ParseException{
+
+        private List<ContentValues> assembleRows() throws ParseException {
             List<ContentValues> rows = new ArrayList<>();
 
-            for (InAppMessage message: mInAppMessages ){
+            for (InAppMessage message : mInAppMessages) {
                 ContentValues values = new ContentValues();
 
                 values.put(InAppMessageTable.COL_ID, message.getInAppId());
 
                 Date inboxDeletedAt = message.getInboxDeletedAt();
                 Date messageDismissedAt = message.getDismissedAt();
-                if (messageDismissedAt != null || inboxDeletedAt != null ){
+                if (messageDismissedAt != null || inboxDeletedAt != null) {
                     Date dismissedTime = messageDismissedAt != null ? messageDismissedAt : inboxDeletedAt;
                     values.put(InAppMessageTable.COL_DISMISSED_AT, dbDateFormat.format(dismissedTime));
                 }
@@ -252,24 +268,24 @@ class InAppContract {
                 }
 
                 Date sentAt = message.getSentAt();
-                if (sentAt != null){
+                if (sentAt != null) {
                     values.put(InAppMessageTable.COL_SENT_AT, dbDateFormat.format(sentAt));
                 }
 
                 String inboxFrom = null;
                 String inboxTo = null;
                 JSONObject inbox = null;
-                if (inboxDeletedAt == null){
+                if (inboxDeletedAt == null) {
                     inbox = message.getInbox();
                 }
 
-                if (inbox != null){
+                if (inbox != null) {
                     inboxFrom = this.getNullableString(inbox, "from");
-                    if (inboxFrom != null){
+                    if (inboxFrom != null) {
                         inboxFrom = this.formatDateForDb(inboxFrom);
                     }
                     inboxTo = this.getNullableString(inbox, "to");
-                    if (inboxTo != null){
+                    if (inboxTo != null) {
                         inboxTo = this.formatDateForDb(inboxTo);
                     }
                 }
@@ -290,12 +306,12 @@ class InAppContract {
             return rows;
         }
 
-        private String formatDateForDb(String date) throws ParseException{
+        private String formatDateForDb(String date) throws ParseException {
             return dbDateFormat.format(incomingDateFormat.parse(date));
         }
 
-        private String getNullableString(JSONObject json, String key){
-            if (!json.has(key) || json.isNull(key)){
+        private String getNullableString(JSONObject json, String key) {
+            if (!json.has(key) || json.isNull(key)) {
                 return null;
             }
 
@@ -328,17 +344,17 @@ class InAppContract {
                         + InAppMessageTable.COL_INBOX_TO + ", "
                         + InAppMessageTable.COL_INBOX_CONFIG_JSON;
 
-                String selectSql ="SELECT "+ columnList +" FROM " + InAppMessageTable.TABLE_NAME +
-                        " WHERE " +InAppMessageTable.COL_INBOX_CONFIG_JSON+" IS NOT NULL "+
-                        " AND (datetime('now') BETWEEN IFNULL("+ InAppMessageTable.COL_INBOX_FROM+", '1970-01-01') AND IFNULL("+ InAppMessageTable.COL_INBOX_TO+", '3970-01-01'))" +
-                        " ORDER BY "+InAppMessageTable.COL_UPDATED_AT+ " DESC";
+                String selectSql = "SELECT " + columnList + " FROM " + InAppMessageTable.TABLE_NAME +
+                        " WHERE " + InAppMessageTable.COL_INBOX_CONFIG_JSON + " IS NOT NULL " +
+                        " AND (datetime('now') BETWEEN IFNULL(" + InAppMessageTable.COL_INBOX_FROM + ", '1970-01-01') AND IFNULL(" + InAppMessageTable.COL_INBOX_TO + ", '3970-01-01'))" +
+                        " ORDER BY " + InAppMessageTable.COL_UPDATED_AT + " DESC";
 
                 Cursor cursor = db.rawQuery(selectSql, new String[]{});
 
                 SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
                 sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-                while(cursor.moveToNext()) {
+                while (cursor.moveToNext()) {
                     int inAppId = cursor.getInt(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_ID));
                     JSONObject inboxConfig = new JSONObject(cursor.getString(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_INBOX_CONFIG_JSON)));
 
@@ -361,18 +377,16 @@ class InAppContract {
                 cursor.close();
 
                 dbHelper.close();
-            }
-            catch (SQLiteException e) {
+            } catch (SQLiteException e) {
                 e.printStackTrace();
-            }
-            catch(Exception e){
+            } catch (Exception e) {
                 Kumulos.log(TAG, e.getMessage());
             }
 
             return inboxItems;
         }
 
-        private Date getNullableDate(Cursor cursor, SimpleDateFormat sdf, String column) throws ParseException{
+        private Date getNullableDate(Cursor cursor, SimpleDateFormat sdf, String column) throws ParseException {
             String date = cursor.getString(cursor.getColumnIndexOrThrow(column));
 
             return date == null ? null : sdf.parse(date);
@@ -399,12 +413,12 @@ class InAppContract {
                 SQLiteDatabase db = dbHelper.getReadableDatabase();
 
                 String[] projection = {InAppMessageTable.COL_ID, InAppMessageTable.COL_CONTENT_JSON};
-                String selection = InAppMessageTable.COL_INBOX_CONFIG_JSON+ " IS NOT NULL AND "+ InAppMessageTable.COL_ID + " = ?";
-                String[] selectionArgs = { mId+"" };
+                String selection = InAppMessageTable.COL_INBOX_CONFIG_JSON + " IS NOT NULL AND " + InAppMessageTable.COL_ID + " = ?";
+                String[] selectionArgs = {mId + ""};
 
-                Cursor cursor = db.query(InAppMessageTable.TABLE_NAME, projection, selection, selectionArgs,null,null, null);
+                Cursor cursor = db.query(InAppMessageTable.TABLE_NAME, projection, selection, selectionArgs, null, null, null);
 
-                if (cursor.moveToFirst()){
+                if (cursor.moveToFirst()) {
                     String content = cursor.getString(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_CONTENT_JSON));
 
                     inboxMessage = new InAppMessage();
@@ -415,11 +429,9 @@ class InAppContract {
                 cursor.close();
 
                 dbHelper.close();
-            }
-            catch (SQLiteException e) {
+            } catch (SQLiteException e) {
                 e.printStackTrace();
-            }
-            catch(Exception e){
+            } catch (Exception e) {
                 Kumulos.log(TAG, e.getMessage());
             }
 
@@ -453,17 +465,16 @@ class InAppContract {
                 values.put(InAppMessageTable.COL_DISMISSED_AT, dbDateFormat.format(new Date()));
 
                 String selection = InAppMessageTable.COL_ID + " = ?";
-                String[] selectionArgs = { mId +"" };
+                String[] selectionArgs = {mId + ""};
 
                 int count = db.update(InAppMessageTable.TABLE_NAME, values, selection, selectionArgs);
 
-                if (count == 0){
+                if (count == 0) {
                     return false;
                 }
                 dbHelper.close();
-            }
-            catch (SQLiteException e) {
-                Kumulos.log(TAG, "Failed to delete inbox message with inAppID: "+ mId);
+            } catch (SQLiteException e) {
+                Kumulos.log(TAG, "Failed to delete inbox message with inAppID: " + mId);
                 e.printStackTrace();
                 return false;
             }
@@ -495,17 +506,16 @@ class InAppContract {
                 values.put(InAppMessageTable.COL_READ_AT, dbDateFormat.format(new Date()));
 
                 String selection = InAppMessageTable.COL_ID + " = ? AND " + InAppMessageTable.COL_READ_AT + " IS NULL";
-                String[] selectionArgs = { mId +"" };
+                String[] selectionArgs = {mId + ""};
 
                 int count = db.update(InAppMessageTable.TABLE_NAME, values, selection, selectionArgs);
 
-                if (count == 0){
+                if (count == 0) {
                     return false;
                 }
                 dbHelper.close();
-            }
-            catch (SQLiteException e) {
-                Kumulos.log(TAG, "Failed to set readAt of inbox message with inAppID: "+ mId);
+            } catch (SQLiteException e) {
+                Kumulos.log(TAG, "Failed to set readAt of inbox message with inAppID: " + mId);
                 e.printStackTrace();
                 return false;
             }

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -40,6 +40,7 @@ class InAppContract {
         static final String COL_CONTENT_JSON = "contentJson";
         static final String COL_EXPIRES_AT = "expiresAt";
         static final String COL_READ_AT = "readAt";
+        static final String COL_SENT_AT = "sentAt";
     }
 
     private static SimpleDateFormat dbDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
@@ -195,7 +196,7 @@ class InAppContract {
 
             String[] projection = {InAppMessageTable.COL_ID, InAppMessageTable.COL_PRESENTED_WHEN, InAppMessageTable.COL_CONTENT_JSON};
             String selection = InAppMessageTable.COL_DISMISSED_AT+ " IS NULL";
-            String sortOrder = InAppMessageTable.COL_UPDATED_AT + " ASC";//TODO:
+            String sortOrder = InAppMessageTable.COL_SENT_AT+ " DESC, " + InAppMessageTable.COL_UPDATED_AT+ " DESC, " + InAppMessageTable.COL_ID + " DESC";
 
             Cursor cursor = db.query(InAppMessageTable.TABLE_NAME, projection, selection, null,null,null, sortOrder);
 
@@ -248,6 +249,11 @@ class InAppContract {
                 Date readAt = message.getReadAt();
                 if (readAt != null) {
                     values.put(InAppMessageTable.COL_READ_AT, dbDateFormat.format(readAt));
+                }
+
+                Date sentAt = message.getSentAt();
+                if (sentAt != null){
+                    values.put(InAppMessageTable.COL_SENT_AT, dbDateFormat.format(sentAt));
                 }
 
                 String inboxFrom = null;

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -45,7 +45,8 @@ class InAppContract {
 
     private static SimpleDateFormat dbDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
     private static SimpleDateFormat incomingDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
-    private static final String SORT_ORDER = InAppMessageTable.COL_SENT_AT + " DESC, " + InAppMessageTable.COL_UPDATED_AT + " DESC, " + InAppMessageTable.COL_ID + " DESC";
+    private static final String DESC_SORT_ORDER = InAppMessageTable.COL_SENT_AT + " DESC, " + InAppMessageTable.COL_UPDATED_AT + " DESC, " + InAppMessageTable.COL_ID + " DESC";
+    private static final String ASC_SORT_ORDER = InAppMessageTable.COL_SENT_AT + " ASC, " + InAppMessageTable.COL_UPDATED_AT + " ASC, " + InAppMessageTable.COL_ID + " ASC";
     private static final Integer STORED_IN_APP_LIMIT = 50;
 
     static {
@@ -181,7 +182,7 @@ class InAppContract {
             String inAppsExceedingLimitSql = "select * from (SELECT " + InAppMessageTable.COL_ID +
                     " FROM " + InAppMessageTable.TABLE_NAME +
                     " WHERE " + notConditions +
-                    " ORDER BY " + SORT_ORDER +
+                    " ORDER BY " + DESC_SORT_ORDER +
                     " LIMIT -1 OFFSET " + STORED_IN_APP_LIMIT + ")";
 
             String readSql = "SELECT inAppId FROM " + InAppMessageTable.TABLE_NAME +
@@ -215,7 +216,7 @@ class InAppContract {
             String[] projection = {InAppMessageTable.COL_ID, InAppMessageTable.COL_PRESENTED_WHEN, InAppMessageTable.COL_CONTENT_JSON};
             String selection = InAppMessageTable.COL_DISMISSED_AT + " IS NULL";
 
-            Cursor cursor = db.query(InAppMessageTable.TABLE_NAME, projection, selection, null, null, null, SORT_ORDER);
+            Cursor cursor = db.query(InAppMessageTable.TABLE_NAME, projection, selection, null, null, null, ASC_SORT_ORDER);
 
             while (cursor.moveToNext()) {
                 int inAppId = cursor.getInt(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_ID));
@@ -347,7 +348,7 @@ class InAppContract {
                 String selectSql = "SELECT " + columnList + " FROM " + InAppMessageTable.TABLE_NAME +
                         " WHERE " + InAppMessageTable.COL_INBOX_CONFIG_JSON + " IS NOT NULL " +
                         " AND (datetime('now') BETWEEN IFNULL(" + InAppMessageTable.COL_INBOX_FROM + ", '1970-01-01') AND IFNULL(" + InAppMessageTable.COL_INBOX_TO + ", '3970-01-01'))" +
-                        " ORDER BY " + InAppMessageTable.COL_UPDATED_AT + " DESC";
+                        " ORDER BY " + DESC_SORT_ORDER;
 
                 Cursor cursor = db.rawQuery(selectSql, new String[]{});
 
@@ -463,6 +464,7 @@ class InAppContract {
                 values.putNull(InAppMessageTable.COL_INBOX_TO);
                 values.putNull(InAppMessageTable.COL_INBOX_CONFIG_JSON);
                 values.put(InAppMessageTable.COL_DISMISSED_AT, dbDateFormat.format(new Date()));
+                values.put(InAppMessageTable.COL_READ_AT, dbDateFormat.format(new Date()));
 
                 String selection = InAppMessageTable.COL_ID + " = ?";
                 String[] selectionArgs = {mId + ""};

--- a/kumulos/src/main/java/com/kumulos/android/InAppDbHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppDbHelper.java
@@ -24,7 +24,8 @@ class InAppDbHelper extends SQLiteOpenHelper {
             + InAppMessageTable.COL_DISMISSED_AT + " DATETIME,"
             + InAppMessageTable.COL_UPDATED_AT + " DATETIME NOT NULL,"
             + InAppMessageTable.COL_EXPIRES_AT + " DATETIME,"
-            + InAppMessageTable.COL_READ_AT + " DATETIME)";
+            + InAppMessageTable.COL_READ_AT + " DATETIME,"
+            + InAppMessageTable.COL_SENT_AT + " DATETIME)";
 
     InAppDbHelper(Context context) {
         super(context, DB_NAME, null, DB_VERSION);
@@ -65,5 +66,6 @@ class InAppDbHelper extends SQLiteOpenHelper {
 
     private void upgradeToVersion3(SQLiteDatabase db){
         db.execSQL("ALTER TABLE " + InAppMessageTable.TABLE_NAME + " ADD COLUMN " + InAppMessageTable.COL_READ_AT + " DATETIME;");
+        db.execSQL("ALTER TABLE " + InAppMessageTable.TABLE_NAME + " ADD COLUMN " + InAppMessageTable.COL_SENT_AT + " DATETIME;");
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppDbHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppDbHelper.java
@@ -9,7 +9,7 @@ import com.kumulos.android.InAppContract.InAppMessageTable;
 
 class InAppDbHelper extends SQLiteOpenHelper {
     private static final String DB_NAME = "k_in_app.db";
-    private static final int DB_VERSION = 2;
+    private static final int DB_VERSION = 3;
 
     private static final String SQL_CREATE_IN_APP_MESSAGES
             = "CREATE TABLE " + InAppMessageTable.TABLE_NAME + "("
@@ -23,7 +23,8 @@ class InAppDbHelper extends SQLiteOpenHelper {
             + InAppMessageTable.COL_INBOX_TO + " DATETIME,"
             + InAppMessageTable.COL_DISMISSED_AT + " DATETIME,"
             + InAppMessageTable.COL_UPDATED_AT + " DATETIME NOT NULL,"
-            + InAppMessageTable.COL_EXPIRES_AT + " DATETIME)";
+            + InAppMessageTable.COL_EXPIRES_AT + " DATETIME,"
+            + InAppMessageTable.COL_READ_AT + " DATETIME)";
 
     InAppDbHelper(Context context) {
         super(context, DB_NAME, null, DB_VERSION);
@@ -42,16 +43,27 @@ class InAppDbHelper extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        switch(newVersion) {
-            case 2:
-                this.upgradeToVersion2(db);
-                break;
-            default:
-                throw new IllegalStateException("onUpgrade() with unknown newVersion " + newVersion);
+
+        for (int i = oldVersion+1; i <= newVersion; ++i) {
+            switch(i) {
+                case 2:
+                    this.upgradeToVersion2(db);
+                    break;
+                case 3:
+                    this.upgradeToVersion3(db);
+                    break;
+                default:
+                    throw new IllegalStateException("onUpgrade() with unknown newVersion " + newVersion);
+            }
         }
+
     }
 
     private void upgradeToVersion2(SQLiteDatabase db){
         db.execSQL("ALTER TABLE " + InAppMessageTable.TABLE_NAME + " ADD COLUMN " + InAppMessageTable.COL_EXPIRES_AT + " DATETIME;");
+    }
+
+    private void upgradeToVersion3(SQLiteDatabase db){
+        db.execSQL("ALTER TABLE " + InAppMessageTable.TABLE_NAME + " ADD COLUMN " + InAppMessageTable.COL_READ_AT + " DATETIME;");
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
@@ -17,6 +17,8 @@ public class InAppInboxItem {
     private Date availableTo;
     @Nullable
     private Date dismissedAt;
+    @Nullable
+    private Date readAt;
 
     public int getId() {
         return id;
@@ -67,5 +69,13 @@ public class InAppInboxItem {
 
     void setDismissedAt(@Nullable Date dismissedAt) {
         this.dismissedAt = dismissedAt;
+    }
+
+    public boolean isRead() {
+        return readAt != null;
+    }
+
+    void setReadAt(@Nullable Date readAt) {
+        this.readAt = readAt;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
@@ -29,6 +29,8 @@ class InAppMessage {
     private Date expiresAt = null;
     @Nullable
     private Date inboxDeletedAt;
+    @Nullable
+    private Date readAt;
 
     InAppMessage(){}
 
@@ -54,6 +56,10 @@ class InAppMessage {
 
         if (!obj.isNull("inboxDeletedAt")) {
             this.inboxDeletedAt = sdf.parse(obj.getString("inboxDeletedAt"));
+        }
+
+        if (!obj.isNull("readAt")) {
+            this.readAt = sdf.parse(obj.getString("readAt"));
         }
     }
 
@@ -115,5 +121,10 @@ class InAppMessage {
     @Nullable
     Date getInboxDeletedAt() {
         return inboxDeletedAt;
+    }
+
+    @Nullable
+    Date getReadAt() {
+        return readAt;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
@@ -31,6 +31,8 @@ class InAppMessage {
     private Date inboxDeletedAt;
     @Nullable
     private Date readAt;
+    @Nullable
+    private Date sentAt;
 
     InAppMessage(){}
 
@@ -60,6 +62,10 @@ class InAppMessage {
 
         if (!obj.isNull("readAt")) {
             this.readAt = sdf.parse(obj.getString("readAt"));
+        }
+
+        if (!obj.isNull("sentAt")) {
+            this.sentAt = sdf.parse(obj.getString("sentAt"));
         }
     }
 
@@ -126,5 +132,10 @@ class InAppMessage {
     @Nullable
     Date getReadAt() {
         return readAt;
+    }
+
+    @Nullable
+    Date getSentAt() {
+        return sentAt;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -47,7 +47,7 @@ class InAppMessagePresenter {
     private static final String HOST_MESSAGE_TYPE_SET_NOTCH_INSETS = "SET_NOTCH_INSETS";
     private static final String IN_APP_RENDERER_URL = "https://iar.app.delivery";
 
-    private static List<InAppMessage> messageQueue = new ArrayList<>();
+    private static final List<InAppMessage> messageQueue = new ArrayList<>();
     @SuppressLint("StaticFieldLeak")
     private static WebView wv = null;
     private static Dialog dialog = null;
@@ -284,15 +284,23 @@ class InAppMessagePresenter {
     }
 
     private static void setSpinnerVisibility(int visibility){
+        if (wv == null){
+            return;
+        }
         wv.post(new Runnable() {
             @Override
             public void run() {
-                spinner.setVisibility(visibility);
+                if (spinner != null){
+                    spinner.setVisibility(visibility);
+                }
             }
         });
     }
 
     private static void sendToClient(String type, JSONObject data){
+        if (wv == null){
+            return;
+        }
         wv.post(new Runnable() {
             @Override
             public void run() {
@@ -471,7 +479,7 @@ class InAppMessagePresenter {
                         @Override
                         public void onPageStarted(WebView view, String url, Bitmap favicon) {
                             super.onPageStarted(view, url, favicon);
-                            spinner.setVisibility(View.VISIBLE);
+                            InAppMessagePresenter.setSpinnerVisibility(View.VISIBLE);
                         }
 
                         @Override

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -251,7 +251,7 @@ class InAppMessagePresenter {
     }
 
     static void messageOpened(Context context){
-        InAppMessageService.trackOpenedEvent(context, messageQueue.get(0).getInAppId());
+        InAppMessageService.handleMessageOpened(context, messageQueue.get(0).getInAppId());
         setSpinnerVisibility(View.GONE);
     }
 

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
@@ -176,7 +176,7 @@ class InAppMessageService {
     }
 
     static void handleMessageOpened(Context context, int id) {
-        markInboxItemRead(context, id);
+        markInboxItemRead(context, id, false);
 
         JSONObject params = new JSONObject();
         try {
@@ -278,15 +278,17 @@ class InAppMessageService {
         return result;
     }
 
-    static boolean markInboxItemRead(Context context, int id) {
+    static boolean markInboxItemRead(Context context, int id, boolean shouldWaitForResult) {
         Callable<Boolean> task = new InAppContract.MarkInAppInboxMessageAsReadCallable(context, id);
         final Future<Boolean> future = Kumulos.executorService.submit(task);
 
-        Boolean result = false;
-        try {
-            result = future.get();
-        } catch (InterruptedException | ExecutionException ex) {
-            Kumulos.log(TAG, ex.getMessage());
+        Boolean result = true;
+        if (shouldWaitForResult){
+            try {
+                result = future.get();
+            } catch (InterruptedException | ExecutionException ex) {
+                Kumulos.log(TAG, ex.getMessage());
+            }
         }
 
         if (!result){
@@ -316,7 +318,7 @@ class InAppMessageService {
                 continue;
             }
 
-            if (!markInboxItemRead(context, item.getId())){
+            if (!markInboxItemRead(context, item.getId(), true)){
                 result = false;
             }
         }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
@@ -303,6 +303,22 @@ class InAppMessageService {
         return result;
     }
 
+    static boolean markAllInboxItemsAsRead(Context context) {
+        List<InAppInboxItem> inboxItems = readInboxItems(context);
+        boolean result = true;
+        for(InAppInboxItem item: inboxItems){
+            if (item.isRead()){
+                continue;
+            }
+
+            if (!markInboxItemRead(context, item.getId())){
+                result = false;
+            }
+        }
+
+        return result;
+    }
+
     private static class ReadAndPresentMessagesRunnable implements Runnable {
         private static final String TAG = ReadAndPresentMessagesRunnable.class.getName();
 

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
@@ -175,7 +175,9 @@ class InAppMessageService {
         }
     }
 
-    static void trackOpenedEvent(Context context, int id) {
+    static void handleMessageOpened(Context context, int id) {
+        markInboxItemRead(context, id);
+
         JSONObject params = new JSONObject();
         try {
             params.put("type", AnalyticsContract.MESSAGE_TYPE_IN_APP);

--- a/kumulos/src/main/java/com/kumulos/android/InAppSaveResult.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppSaveResult.java
@@ -1,0 +1,27 @@
+package com.kumulos.android;
+
+import java.util.List;
+
+public class InAppSaveResult {
+    List<InAppMessage> itemsToPresent;
+    List<Integer> deliveredIds;
+    List<Integer> deletedIds;
+
+    public InAppSaveResult(List<InAppMessage> itemsToPresent, List<Integer> deliveredIds, List<Integer> deletedIds) {
+        this.itemsToPresent = itemsToPresent;
+        this.deliveredIds = deliveredIds;
+        this.deletedIds = deletedIds;
+    }
+
+    public List<InAppMessage> getItemsToPresent() {
+        return itemsToPresent;
+    }
+
+    public List<Integer> getDeliveredIds() {
+        return deliveredIds;
+    }
+
+    public List<Integer> getDeletedIds() {
+        return deletedIds;
+    }
+}

--- a/kumulos/src/main/java/com/kumulos/android/InAppSaveResult.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppSaveResult.java
@@ -2,26 +2,26 @@ package com.kumulos.android;
 
 import java.util.List;
 
-public class InAppSaveResult {
+class InAppSaveResult {
     List<InAppMessage> itemsToPresent;
     List<Integer> deliveredIds;
     List<Integer> deletedIds;
 
-    public InAppSaveResult(List<InAppMessage> itemsToPresent, List<Integer> deliveredIds, List<Integer> deletedIds) {
+    InAppSaveResult(List<InAppMessage> itemsToPresent, List<Integer> deliveredIds, List<Integer> deletedIds) {
         this.itemsToPresent = itemsToPresent;
         this.deliveredIds = deliveredIds;
         this.deletedIds = deletedIds;
     }
 
-    public List<InAppMessage> getItemsToPresent() {
+    List<InAppMessage> getItemsToPresent() {
         return itemsToPresent;
     }
 
-    public List<Integer> getDeliveredIds() {
+    List<Integer> getDeliveredIds() {
         return deliveredIds;
     }
 
-    public List<Integer> getDeletedIds() {
+    List<Integer> getDeletedIds() {
         return deletedIds;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -46,6 +46,9 @@ public class KumulosInApp {
     }
 
     public static boolean markAsRead(Context context, InAppInboxItem item){
+        if (item.isRead()){
+            return false;
+        }
         return InAppMessageService.markInboxItemRead(context, item.getId());
     }
 

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -49,9 +49,9 @@ public class KumulosInApp {
         return InAppMessageService.markInboxItemRead(context, item.getId());
     }
 
-//    public static boolean markAllInboxItemsAsRead(Context context){
-//        return InAppMessageService.deleteMessageFromInbox(context);
-//    }
+    public static boolean markAllInboxItemsAsRead(Context context){
+        return InAppMessageService.markAllInboxItemsAsRead(context);
+    }
 
     /**
      * Used to update in-app consent when enablement strategy is EXPLICIT_BY_USER

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -45,6 +45,14 @@ public class KumulosInApp {
         return InAppMessageService.deleteMessageFromInbox(context, item.getId());
     }
 
+    public static boolean markAsRead(Context context, InAppInboxItem item){
+        return InAppMessageService.markInboxItemRead(context, item.getId());
+    }
+
+//    public static boolean markAllInboxItemsAsRead(Context context){
+//        return InAppMessageService.deleteMessageFromInbox(context);
+//    }
+
     /**
      * Used to update in-app consent when enablement strategy is EXPLICIT_BY_USER
      *

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -49,7 +49,7 @@ public class KumulosInApp {
         if (item.isRead()){
             return false;
         }
-        return InAppMessageService.markInboxItemRead(context, item.getId());
+        return InAppMessageService.markInboxItemRead(context, item.getId(), true);
     }
 
     public static boolean markAllInboxItemsAsRead(Context context){


### PR DESCRIPTION
### Description of Changes

New message property 'read'. The meaning of ‘message read’ is “User has seen the message, but not necessarily opened it”. Mark message as read when
1) message opened
2) inbox item deleted
3) Inbox item explicitly marked by user as read. For this expose 2 new public methods: `boolean markAsRead(Context context, InAppInboxItem item)` and `boolean markAllInboxItemsAsRead(Context context)`. Methods return true if all updates succeeded.

Additionally,
1) Consistent sort order of inbox items. sentAt DESC, updatedAt DESC, inAppId DESC. When presenting sorting fields same, but ASC
2) limit maximal amount of stored inApps to 50. Even if inbox is set to always, 51st message is going to be deleted (51st is the oldest).
3) Clear push tickle whenever inApp is deleted. We used to do this when message is dismissed, inbox item deleted or message is marked read (and other). Now also when message expires or when delete message exceeding limit
### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
