### PR TITLE
In-app inbox extensions (updated hook, new fields, summary method)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.5.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.5.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.6.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.6.0'
 }
 ```
 

--- a/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
+++ b/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
@@ -3,6 +3,7 @@ package com.kumulos.android;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+
 import com.google.firebase.messaging.RemoteMessage;
 
 import org.json.JSONArray;
@@ -16,7 +17,7 @@ import androidx.annotation.Nullable;
 
 /**
  * FirebaseMessageHandler provides helpers for handling FirebaseMessagingService events
- *
+ * <p>
  * This can allow interoperating Kumulos push with your own FCM service
  */
 public class FirebaseMessageHandler {
@@ -26,6 +27,7 @@ public class FirebaseMessageHandler {
     /**
      * Handles the received notification from FCM, creating a PushMessage model and broadcasting
      * the appropriate com.kumulos.push Intent
+     *
      * @param context
      * @param remoteMessage
      */

--- a/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
+++ b/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
@@ -3,7 +3,6 @@ package com.kumulos.android;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-
 import com.google.firebase.messaging.RemoteMessage;
 
 import org.json.JSONArray;
@@ -79,7 +78,8 @@ public class FirebaseMessageHandler {
                 runBackgroundHandler,
                 pictureUrl,
                 buttons,
-                sound
+                sound,
+                remoteMessage.getCollapseKey()
         );
 
         Intent intent = new Intent(PushBroadcastReceiver.ACTION_PUSH_RECEIVED);

--- a/kumulos/src/main/java/com/kumulos/android/HmsMessageHandler.java
+++ b/kumulos/src/main/java/com/kumulos/android/HmsMessageHandler.java
@@ -80,7 +80,8 @@ public class HmsMessageHandler {
                 runBackgroundHandler,
                 pictureUrl,
                 buttons,
-                sound
+                sound,
+                remoteMessage.getCollapseKey()
         );
 
         Intent intent = new Intent(PushBroadcastReceiver.ACTION_PUSH_RECEIVED);

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -341,6 +341,8 @@ class InAppContract {
                 String columnList = InAppMessageTable.COL_ID + ", "
                         + InAppMessageTable.COL_DISMISSED_AT + ", "
                         + InAppMessageTable.COL_READ_AT + ", "
+                        + InAppMessageTable.COL_SENT_AT + ", "
+                        + InAppMessageTable.COL_DATA_JSON + ", "
                         + InAppMessageTable.COL_INBOX_FROM + ", "
                         + InAppMessageTable.COL_INBOX_TO + ", "
                         + InAppMessageTable.COL_INBOX_CONFIG_JSON;
@@ -358,11 +360,13 @@ class InAppContract {
                 while (cursor.moveToNext()) {
                     int inAppId = cursor.getInt(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_ID));
                     JSONObject inboxConfig = new JSONObject(cursor.getString(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_INBOX_CONFIG_JSON)));
+                    JSONObject data = new JSONObject(cursor.getString(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_DATA_JSON)));
 
                     Date availableFrom = this.getNullableDate(cursor, sdf, InAppMessageTable.COL_INBOX_FROM);
                     Date availableTo = this.getNullableDate(cursor, sdf, InAppMessageTable.COL_INBOX_TO);
                     Date dismissedAt = this.getNullableDate(cursor, sdf, InAppMessageTable.COL_DISMISSED_AT);
                     Date readAt = this.getNullableDate(cursor, sdf, InAppMessageTable.COL_READ_AT);
+                    Date sentAt = this.getNullableDate(cursor, sdf, InAppMessageTable.COL_SENT_AT);
 
                     InAppInboxItem i = new InAppInboxItem();
                     i.setId(inAppId);
@@ -370,6 +374,8 @@ class InAppContract {
                     i.setReadAt(readAt);
                     i.setAvailableTo(availableTo);
                     i.setAvailableFrom(availableFrom);
+                    i.setSentAt(sentAt);
+                    i.setData(data);
 
                     i.setTitle(inboxConfig.getString("title"));
                     i.setSubtitle(inboxConfig.getString("subtitle"));

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -589,7 +589,7 @@ class InAppContract {
         public void run() {
             SQLiteOpenHelper dbHelper = new InAppDbHelper(mContext);
 
-            InAppInboxSummaryInfo summary = null;
+            InAppInboxSummary summary = null;
             try {
                 SQLiteDatabase db = dbHelper.getReadableDatabase();
 
@@ -606,7 +606,7 @@ class InAppContract {
                 int unreadCount = cursor.getInt(cursor.getColumnIndexOrThrow("unreadCount"));
                 cursor.close();
 
-                summary = new InAppInboxSummaryInfo(totalCount, unreadCount);
+                summary = new InAppInboxSummary(totalCount, unreadCount);
 
                 dbHelper.close();
             } catch (SQLiteException e) {
@@ -618,7 +618,7 @@ class InAppContract {
             this.fireCallback(summary);
         }
 
-        private void fireCallback(InAppInboxSummaryInfo summary){
+        private void fireCallback(InAppInboxSummary summary){
             Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
             if (currentActivity == null){
                 return;

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -239,8 +239,9 @@ class InAppContract {
             boolean evictedInbox = false;
             while (c.moveToNext()) {
                 deletedIds.add(c.getInt(c.getColumnIndexOrThrow(InAppMessageTable.COL_ID)));
-                String inbox = c.getString(c.getColumnIndexOrThrow(InAppMessageTable.COL_INBOX_CONFIG_JSON));
-                if (inbox != null) {
+
+                boolean hasInbox = !c.isNull(c.getColumnIndexOrThrow(InAppMessageTable.COL_INBOX_CONFIG_JSON));
+                if (hasInbox) {
                     evictedInbox = true;
                 }
             }

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -14,6 +14,7 @@ import androidx.annotation.Nullable;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.lang.ref.WeakReference;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -578,11 +579,11 @@ class InAppContract {
 
         private static final String TAG = ReadInboxSummaryRunnable.class.getName();
         private final Context mContext;
-        private final KumulosInApp.InAppInboxSummaryHandler callback;
+        private final WeakReference<KumulosInApp.InAppInboxSummaryHandler> callbackRef;
 
         ReadInboxSummaryRunnable(Context context, KumulosInApp.InAppInboxSummaryHandler callback) {
             mContext = context.getApplicationContext();
-            this.callback = callback;
+            this.callbackRef = new WeakReference<>(callback);
         }
 
         @Override
@@ -624,10 +625,15 @@ class InAppContract {
                 return;
             }
 
+            KumulosInApp.InAppInboxSummaryHandler callback = this.callbackRef.get();
+            if (callback == null){
+                return;
+            }
+
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    ReadInboxSummaryRunnable.this.callback.run(summary);
+                    callback.run(summary);
                 }
             });
         }

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -577,11 +577,11 @@ class InAppContract {
 
         private static final String TAG = ReadInboxSummaryRunnable.class.getName();
         private final Context mContext;
-        private final WeakReference<KumulosInApp.InAppInboxSummaryHandler> callbackRef;
+        private final KumulosInApp.InAppInboxSummaryHandler callback;
 
         ReadInboxSummaryRunnable(Context context, KumulosInApp.InAppInboxSummaryHandler callback) {
             mContext = context.getApplicationContext();
-            this.callbackRef = new WeakReference<>(callback);
+            this.callback = callback;
         }
 
         @Override
@@ -617,25 +617,18 @@ class InAppContract {
             this.fireCallback(summary);
         }
 
-        private void fireCallback(InAppInboxSummary summary){
+        private void fireCallback(InAppInboxSummary summary) {
             Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
-            if (currentActivity == null){
-                return;
-            }
-
-            KumulosInApp.InAppInboxSummaryHandler callback = this.callbackRef.get();
-            if (callback == null){
+            if (currentActivity == null) {
                 return;
             }
 
             currentActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    callback.run(summary);
+                    ReadInboxSummaryRunnable.this.callback.run(summary);
                 }
             });
         }
     }
-
-
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -239,7 +239,7 @@ class InAppContract {
             while (c.moveToNext()) {
                 deletedIds.add(c.getInt(c.getColumnIndexOrThrow(InAppMessageTable.COL_ID)));
 
-                if (!evictedInbox){
+                if (!evictedInbox) {
                     evictedInbox = !c.isNull(c.getColumnIndexOrThrow(InAppMessageTable.COL_INBOX_CONFIG_JSON));
                 }
             }

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -273,20 +273,18 @@ class InAppContract {
                 int inAppId = cursor.getInt(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_ID));
                 String presentedWhen = cursor.getString(cursor.getColumnIndexOrThrow(InAppMessageTable.COL_PRESENTED_WHEN));
                 Date readAt = getNullableDate(cursor, InAppMessageTable.COL_READ_AT);
-
-                InAppMessage m = new InAppMessage();
-                m.setInAppId(inAppId);
-                m.setPresentedWhen(presentedWhen);
-                m.setReadAt(readAt);
+                JSONObject content = null;
+                JSONObject inbox = null;
 
                 try {
-                    m.setContent(getNullableJsonObject(cursor, InAppMessageTable.COL_CONTENT_JSON));
-                    m.setInbox(getNullableJsonObject(cursor, InAppMessageTable.COL_INBOX_CONFIG_JSON));
+                    content = getNullableJsonObject(cursor, InAppMessageTable.COL_CONTENT_JSON);
+                    inbox = getNullableJsonObject(cursor, InAppMessageTable.COL_INBOX_CONFIG_JSON);
                 } catch (JSONException e) {
                     Kumulos.log(TAG, e.getMessage());
                     continue;
                 }
 
+                InAppMessage m = new InAppMessage(inAppId, presentedWhen, content, inbox, readAt);
                 itemsToPresent.add(m);
             }
 
@@ -469,11 +467,10 @@ class InAppContract {
                 Cursor cursor = db.query(InAppMessageTable.TABLE_NAME, projection, selection, selectionArgs, null, null, null);
 
                 if (cursor.moveToFirst()) {
-                    inboxMessage = new InAppMessage();
-                    inboxMessage.setInAppId(mId);
-                    inboxMessage.setContent(getNullableJsonObject(cursor, InAppMessageTable.COL_CONTENT_JSON));
-                    inboxMessage.setReadAt(getNullableDate(cursor, InAppMessageTable.COL_READ_AT));
-                    inboxMessage.setInbox(getNullableJsonObject(cursor, InAppMessageTable.COL_INBOX_CONFIG_JSON));
+                    inboxMessage = new InAppMessage(mId,
+                            getNullableJsonObject(cursor, InAppMessageTable.COL_CONTENT_JSON),
+                            getNullableJsonObject(cursor, InAppMessageTable.COL_INBOX_CONFIG_JSON),
+                            getNullableDate(cursor, InAppMessageTable.COL_READ_AT));
                 }
 
                 cursor.close();

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.lang.ref.WeakReference;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -240,9 +239,8 @@ class InAppContract {
             while (c.moveToNext()) {
                 deletedIds.add(c.getInt(c.getColumnIndexOrThrow(InAppMessageTable.COL_ID)));
 
-                boolean hasInbox = !c.isNull(c.getColumnIndexOrThrow(InAppMessageTable.COL_INBOX_CONFIG_JSON));
-                if (hasInbox) {
-                    evictedInbox = true;
+                if (!evictedInbox){
+                    evictedInbox = !c.isNull(c.getColumnIndexOrThrow(InAppMessageTable.COL_INBOX_CONFIG_JSON));
                 }
             }
             c.close();

--- a/kumulos/src/main/java/com/kumulos/android/InAppDbHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppDbHelper.java
@@ -9,7 +9,7 @@ import com.kumulos.android.InAppContract.InAppMessageTable;
 
 class InAppDbHelper extends SQLiteOpenHelper {
     private static final String DB_NAME = "k_in_app.db";
-    private static final int DB_VERSION = 3;
+    private static final int DB_VERSION = 4;
 
     private static final String SQL_CREATE_IN_APP_MESSAGES
             = "CREATE TABLE " + InAppMessageTable.TABLE_NAME + "("
@@ -35,8 +35,7 @@ class InAppDbHelper extends SQLiteOpenHelper {
     public void onCreate(SQLiteDatabase db) {
         try {
             db.execSQL(SQL_CREATE_IN_APP_MESSAGES);
-        }
-        catch (SQLException e) {
+        } catch (SQLException e) {
             Kumulos.log("Failed to create in app table");
             e.printStackTrace();
         }
@@ -45,13 +44,16 @@ class InAppDbHelper extends SQLiteOpenHelper {
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
 
-        for (int i = oldVersion+1; i <= newVersion; ++i) {
-            switch(i) {
+        for (int i = oldVersion + 1; i <= newVersion; ++i) {
+            switch (i) {
                 case 2:
                     this.upgradeToVersion2(db);
                     break;
                 case 3:
                     this.upgradeToVersion3(db);
+                    break;
+                case 4:
+                    this.upgradeToVersion4(db);
                     break;
                 default:
                     throw new IllegalStateException("onUpgrade() with unknown newVersion " + newVersion);
@@ -60,12 +62,18 @@ class InAppDbHelper extends SQLiteOpenHelper {
 
     }
 
-    private void upgradeToVersion2(SQLiteDatabase db){
+    private void upgradeToVersion2(SQLiteDatabase db) {
         db.execSQL("ALTER TABLE " + InAppMessageTable.TABLE_NAME + " ADD COLUMN " + InAppMessageTable.COL_EXPIRES_AT + " DATETIME;");
     }
 
-    private void upgradeToVersion3(SQLiteDatabase db){
+    private void upgradeToVersion3(SQLiteDatabase db) {
         db.execSQL("ALTER TABLE " + InAppMessageTable.TABLE_NAME + " ADD COLUMN " + InAppMessageTable.COL_READ_AT + " DATETIME;");
         db.execSQL("ALTER TABLE " + InAppMessageTable.TABLE_NAME + " ADD COLUMN " + InAppMessageTable.COL_SENT_AT + " DATETIME;");
+    }
+
+    private void upgradeToVersion4(SQLiteDatabase db) {
+        db.execSQL("UPDATE " + InAppMessageTable.TABLE_NAME +
+                " SET " + InAppMessageTable.COL_SENT_AT + " = " + InAppMessageTable.COL_UPDATED_AT +
+                " WHERE " + InAppMessageTable.COL_SENT_AT + " IS NULL ");
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
@@ -22,7 +22,6 @@ public class InAppInboxItem {
     private Date dismissedAt;
     @Nullable
     private Date readAt;
-    @Nullable
     private Date sentAt;
     @Nullable
     private JSONObject data;
@@ -86,10 +85,10 @@ public class InAppInboxItem {
         this.readAt = readAt;
     }
 
-    public @Nullable Date getSentAt() {
+    public Date getSentAt() {
         return sentAt;
     }
-    void setSentAt(@Nullable Date sentAt) {
+    void setSentAt(Date sentAt) {
         this.sentAt = sentAt;
     }
 

--- a/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
@@ -2,7 +2,10 @@ package com.kumulos.android;
 
 import java.util.Date;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.json.JSONObject;
 
 public class InAppInboxItem {
 
@@ -19,6 +22,10 @@ public class InAppInboxItem {
     private Date dismissedAt;
     @Nullable
     private Date readAt;
+    @Nullable
+    private Date sentAt;
+    @Nullable
+    private JSONObject data;
 
     public int getId() {
         return id;
@@ -77,5 +84,19 @@ public class InAppInboxItem {
 
     void setReadAt(@Nullable Date readAt) {
         this.readAt = readAt;
+    }
+
+    public @Nullable Date getSentAt() {
+        return sentAt;
+    }
+    void setSentAt(@Nullable Date sentAt) {
+        this.sentAt = sentAt;
+    }
+
+    public @Nullable JSONObject getData() {
+        return data;
+    }
+    void setData(@Nullable JSONObject data) {
+        this.data = data;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
@@ -9,7 +9,8 @@ import org.json.JSONObject;
 
 public class InAppInboxItem {
 
-    InAppInboxItem(){ }
+    InAppInboxItem() {
+    }
 
     private int id;
     private String title;
@@ -88,13 +89,16 @@ public class InAppInboxItem {
     public Date getSentAt() {
         return sentAt;
     }
+
     void setSentAt(Date sentAt) {
         this.sentAt = sentAt;
     }
 
-    public @Nullable JSONObject getData() {
+    public @Nullable
+    JSONObject getData() {
         return data;
     }
+
     void setData(@Nullable JSONObject data) {
         this.data = data;
     }

--- a/kumulos/src/main/java/com/kumulos/android/InAppInboxSummary.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppInboxSummary.java
@@ -1,10 +1,10 @@
 package com.kumulos.android;
 
-public class InAppInboxSummaryInfo {
+public class InAppInboxSummary {
     private final int totalCount;
     private final int unreadCount;
 
-    InAppInboxSummaryInfo(int totalCount, int unreadCount) {
+    InAppInboxSummary(int totalCount, int unreadCount) {
         this.totalCount = totalCount;
         this.unreadCount = unreadCount;
     }

--- a/kumulos/src/main/java/com/kumulos/android/InAppInboxSummaryInfo.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppInboxSummaryInfo.java
@@ -1,0 +1,19 @@
+package com.kumulos.android;
+
+public class InAppInboxSummaryInfo {
+    private final int totalCount;
+    private final int unreadCount;
+
+    InAppInboxSummaryInfo(int totalCount, int unreadCount) {
+        this.totalCount = totalCount;
+        this.unreadCount = unreadCount;
+    }
+
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    public int getUnreadCount() {
+        return unreadCount;
+    }
+}

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
@@ -34,7 +34,8 @@ class InAppMessage {
     @Nullable
     private Date sentAt;
 
-    InAppMessage(){}
+    InAppMessage() {
+    }
 
     InAppMessage(JSONObject obj) throws JSONException, ParseException {
         this.inAppId = obj.getInt("id");
@@ -46,14 +47,14 @@ class InAppMessage {
 
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        this.updatedAt =  sdf.parse(obj.getString("updatedAt"));
+        this.updatedAt = sdf.parse(obj.getString("updatedAt"));
 
         if (!obj.isNull("openedAt")) {
             this.dismissedAt = sdf.parse(obj.getString("openedAt"));
         }
 
         if (!obj.isNull("expiresAt")) {
-            this.expiresAt =  sdf.parse(obj.getString("expiresAt"));
+            this.expiresAt = sdf.parse(obj.getString("expiresAt"));
         }
 
         if (!obj.isNull("inboxDeletedAt")) {
@@ -95,14 +96,17 @@ class InAppMessage {
     Date getDismissedAt() {
         return dismissedAt;
     }
+
     @Nullable
     Date getUpdatedAt() {
         return updatedAt;
     }
+
     @Nullable
     Date getExpiresAt() {
         return expiresAt;
     }
+
     @Nullable
     JSONObject getInbox() {
         return inbox;
@@ -112,19 +116,19 @@ class InAppMessage {
         this.inbox = inbox;
     }
 
-    void setInAppId(int id){
+    void setInAppId(int id) {
         this.inAppId = id;
     }
 
-    void setContent(JSONObject content){
+    void setContent(JSONObject content) {
         this.content = content;
     }
 
-    void setDismissedAt(@Nullable Date dismissedAt){
+    void setDismissedAt(@Nullable Date dismissedAt) {
         this.dismissedAt = dismissedAt;
     }
 
-    void setPresentedWhen(String presentedWhen){
+    void setPresentedWhen(String presentedWhen) {
         this.presentedWhen = presentedWhen;
     }
 
@@ -138,7 +142,7 @@ class InAppMessage {
         return readAt;
     }
 
-    void setReadAt(@Nullable Date readAt){
+    void setReadAt(@Nullable Date readAt) {
         this.readAt = readAt;
     }
 

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
@@ -108,6 +108,10 @@ class InAppMessage {
         return inbox;
     }
 
+    void setInbox(@Nullable JSONObject inbox) {
+        this.inbox = inbox;
+    }
+
     void setInAppId(int id){
         this.inAppId = id;
     }
@@ -132,6 +136,10 @@ class InAppMessage {
     @Nullable
     Date getReadAt() {
         return readAt;
+    }
+
+    void setReadAt(@Nullable Date readAt){
+        this.readAt = readAt;
     }
 
     @Nullable

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
@@ -68,7 +68,7 @@ class InAppMessage {
         }
     }
 
-    InAppMessage(int inAppId, String presentedWhen, JSONObject content,  @Nullable JSONObject inbox, @Nullable Date readAt) {
+    InAppMessage(int inAppId, String presentedWhen, JSONObject content, @Nullable JSONObject inbox, @Nullable Date readAt) {
         this.inAppId = inAppId;
         this.presentedWhen = presentedWhen;
         this.content = content;

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
@@ -13,14 +13,14 @@ import androidx.annotation.Nullable;
 
 class InAppMessage {
     private String presentedWhen;
-    private int inAppId;
+    private final int inAppId;
     @Nullable
     private JSONObject badgeConfig;
     @Nullable
     private JSONObject data;
-    private JSONObject content;
+    private final JSONObject content;
     @Nullable
-    private JSONObject inbox;
+    private final JSONObject inbox;
     @Nullable
     private Date dismissedAt = null;
     @Nullable
@@ -34,8 +34,6 @@ class InAppMessage {
     @Nullable
     private Date sentAt;
 
-    InAppMessage() {
-    }
 
     InAppMessage(JSONObject obj) throws JSONException, ParseException {
         this.inAppId = obj.getInt("id");
@@ -68,6 +66,21 @@ class InAppMessage {
         if (!obj.isNull("sentAt")) {
             this.sentAt = sdf.parse(obj.getString("sentAt"));
         }
+    }
+
+    InAppMessage(int inAppId, String presentedWhen, JSONObject content,  @Nullable JSONObject inbox, @Nullable Date readAt) {
+        this.inAppId = inAppId;
+        this.presentedWhen = presentedWhen;
+        this.content = content;
+        this.inbox = inbox;
+        this.readAt = readAt;
+    }
+
+    InAppMessage(int inAppId, JSONObject content, @Nullable JSONObject inbox, @Nullable Date readAt) {
+        this.inAppId = inAppId;
+        this.content = content;
+        this.inbox = inbox;
+        this.readAt = readAt;
     }
 
     int getInAppId() {
@@ -112,26 +125,6 @@ class InAppMessage {
         return inbox;
     }
 
-    void setInbox(@Nullable JSONObject inbox) {
-        this.inbox = inbox;
-    }
-
-    void setInAppId(int id) {
-        this.inAppId = id;
-    }
-
-    void setContent(JSONObject content) {
-        this.content = content;
-    }
-
-    void setDismissedAt(@Nullable Date dismissedAt) {
-        this.dismissedAt = dismissedAt;
-    }
-
-    void setPresentedWhen(String presentedWhen) {
-        this.presentedWhen = presentedWhen;
-    }
-
     @Nullable
     Date getInboxDeletedAt() {
         return inboxDeletedAt;
@@ -142,12 +135,12 @@ class InAppMessage {
         return readAt;
     }
 
-    void setReadAt(@Nullable Date readAt) {
-        this.readAt = readAt;
-    }
-
     @Nullable
     Date getSentAt() {
         return sentAt;
+    }
+
+    void setDismissedAt(@Nullable Date dismissedAt) {
+        this.dismissedAt = dismissedAt;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -251,7 +251,7 @@ class InAppMessagePresenter {
     }
 
     static void messageOpened(Context context){
-        InAppMessageService.handleMessageOpened(context, messageQueue.get(0).getInAppId());
+        InAppMessageService.handleMessageOpened(context, messageQueue.get(0));
         setSpinnerVisibility(View.GONE);
     }
 

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -59,7 +59,7 @@ class InAppMessagePresenter {
     private static boolean presentationPendingOnResume = false;
 
     @AnyThread
-    static synchronized void presentMessages(List<InAppMessage> itemsToPresent, List<Integer> tickleIds){
+    static synchronized void presentMessages(List<InAppMessage> itemsToPresent, List<Integer> tickleIds) {
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
 
         if (currentActivity == null) {
@@ -79,13 +79,13 @@ class InAppMessagePresenter {
         addMessagesToQueue(itemsToPresent);
         moveTicklesToFront(tickleIds);
 
-        if (dialog == null){
+        if (dialog == null) {
             showWebView(currentActivity);
             return;
         }
 
         Activity dialogActivity = getDialogActivity(dialog.getContext());
-        if(dialogActivity.hashCode() != currentActivity.hashCode()){
+        if (dialogActivity.hashCode() != currentActivity.hashCode()) {
             closeDialog(dialogActivity);
             showWebView(currentActivity);
             return;
@@ -98,27 +98,27 @@ class InAppMessagePresenter {
         }
     }
 
-    private static void maybeRefreshFirstMessageInQueue(List<InAppMessage> oldQueue){
-        if (oldQueue.isEmpty()){
+    private static void maybeRefreshFirstMessageInQueue(List<InAppMessage> oldQueue) {
+        if (oldQueue.isEmpty()) {
             return;
         }
 
         InAppMessage oldFront = oldQueue.get(0);
 
-        if (oldFront.getInAppId() != messageQueue.get(0).getInAppId()){
+        if (oldFront.getInAppId() != messageQueue.get(0).getInAppId()) {
             presentMessageToClient();
         }
     }
 
-    private static void moveTicklesToFront(List<Integer> tickleIds){
-        if (tickleIds == null || tickleIds.isEmpty()){
+    private static void moveTicklesToFront(List<Integer> tickleIds) {
+        if (tickleIds == null || tickleIds.isEmpty()) {
             return;
         }
 
-        for (Integer tickleId : tickleIds){
-            for(int i=0; i<messageQueue.size(); i++){
+        for (Integer tickleId : tickleIds) {
+            for (int i = 0; i < messageQueue.size(); i++) {
                 InAppMessage next = messageQueue.get(i);
-                if (tickleId == next.getInAppId()){
+                if (tickleId == next.getInAppId()) {
                     messageQueue.remove(i);
                     messageQueue.add(0, next);
 
@@ -128,25 +128,25 @@ class InAppMessagePresenter {
         }
     }
 
-    private static void addMessagesToQueue(List<InAppMessage> itemsToPresent){
-        for(InAppMessage messageToAppend: itemsToPresent){
+    private static void addMessagesToQueue(List<InAppMessage> itemsToPresent) {
+        for (InAppMessage messageToAppend : itemsToPresent) {
             boolean exists = false;
-            for (InAppMessage messageFromQueue: messageQueue){
-                if (messageToAppend.getInAppId() == messageFromQueue.getInAppId()){
+            for (InAppMessage messageFromQueue : messageQueue) {
+                if (messageToAppend.getInAppId() == messageFromQueue.getInAppId()) {
                     exists = true;
                     break;
                 }
             }
 
-            if (!exists){
+            if (!exists) {
                 messageQueue.add(messageToAppend);
             }
         }
     }
 
-    private static void presentMessageToClient(){
+    private static void presentMessageToClient() {
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
-        if (currentActivity == null){
+        if (currentActivity == null) {
             presentationPendingOnResume = true;
 
             return;
@@ -154,13 +154,13 @@ class InAppMessagePresenter {
 
         presentationPendingOnResume = false;
 
-        if (messageQueue.isEmpty()){
+        if (messageQueue.isEmpty()) {
             closeDialog(currentActivity);
 
             return;
         }
 
-        if (dialog == null){
+        if (dialog == null) {
             return;
         }
 
@@ -170,8 +170,8 @@ class InAppMessagePresenter {
         sendToClient(HOST_MESSAGE_TYPE_PRESENT_MESSAGE, message.getContent());
     }
 
-    static void clientReady(Context context){
-        if (wv == null){
+    static void clientReady(Context context) {
+        if (wv == null) {
             return;
         }
 
@@ -184,18 +184,18 @@ class InAppMessagePresenter {
         });
     }
 
-    private static void maybeSetNotchInsets(Context context){
-        if (dialog == null){
+    private static void maybeSetNotchInsets(Context context) {
+        if (dialog == null) {
             return;
         }
 
         Window window = dialog.getWindow();
-        if (window == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.P){
+        if (window == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             return;
         }
 
         DisplayCutout displayCutout = window.getDecorView().getRootWindowInsets().getDisplayCutout();
-        if (displayCutout == null){
+        if (displayCutout == null) {
             return;
         }
 
@@ -208,7 +208,7 @@ class InAppMessagePresenter {
         float density = context.getResources().getDisplayMetrics().density;
 
         JSONObject notchData = new JSONObject();
-        try{
+        try {
             notchData.put("hasNotchOnTheLeft", notchPositions.first);
             notchData.put("hasNotchOnTheRight", notchPositions.second);
             notchData.put("insetTop", displayCutout.getSafeInsetTop() / density);
@@ -217,32 +217,28 @@ class InAppMessagePresenter {
             notchData.put("insetLeft", displayCutout.getSafeInsetLeft() / density);
 
             sendToClient(HOST_MESSAGE_TYPE_SET_NOTCH_INSETS, notchData);
-        }
-        catch(JSONException e){
+        } catch (JSONException e) {
             Kumulos.log(TAG, e.getMessage());
         }
     }
 
-    private static Pair<Boolean, Boolean> determineNotchPositions(Window window, List<Rect> cutoutBoundingRectangles){
+    private static Pair<Boolean, Boolean> determineNotchPositions(Window window, List<Rect> cutoutBoundingRectangles) {
         Display display = window.getWindowManager().getDefaultDisplay();
-        DisplayMetrics outMetrics = new DisplayMetrics ();
+        DisplayMetrics outMetrics = new DisplayMetrics();
         display.getMetrics(outMetrics);
 
         boolean hasNotchOnTheRight = false;
         boolean hasNotchOnTheLeft = false;
-        for (Rect rect: cutoutBoundingRectangles){
-            if (rect.top == 0){
-                if (rect.left > outMetrics.widthPixels - rect.right){
+        for (Rect rect : cutoutBoundingRectangles) {
+            if (rect.top == 0) {
+                if (rect.left > outMetrics.widthPixels - rect.right) {
                     hasNotchOnTheRight = true;
-                }
-                else if (rect.left < outMetrics.widthPixels - rect.right){
+                } else if (rect.left < outMetrics.widthPixels - rect.right) {
                     hasNotchOnTheLeft = true;
                 }
-            }
-            else if (rect.right >= outMetrics.widthPixels){
+            } else if (rect.right >= outMetrics.widthPixels) {
                 hasNotchOnTheRight = true;
-            }
-            else if (rect.left == 0){
+            } else if (rect.left == 0) {
                 hasNotchOnTheLeft = true;
             }
         }
@@ -250,13 +246,13 @@ class InAppMessagePresenter {
         return new Pair<Boolean, Boolean>(hasNotchOnTheLeft, hasNotchOnTheRight);
     }
 
-    static void messageOpened(Context context){
+    static void messageOpened(Context context) {
         InAppMessageService.handleMessageOpened(context, messageQueue.get(0));
         setSpinnerVisibility(View.GONE);
     }
 
-    static void messageClosed(){
-        if (wv == null){
+    static void messageClosed() {
+        if (wv == null) {
             return;
         }
 
@@ -271,8 +267,8 @@ class InAppMessagePresenter {
         });
     }
 
-    static void closeCurrentMessage(Context context){
-        if (dialog == null || messageQueue.isEmpty()){
+    static void closeCurrentMessage(Context context) {
+        if (dialog == null || messageQueue.isEmpty()) {
             return;
         }
 
@@ -283,38 +279,37 @@ class InAppMessagePresenter {
         InAppMessageService.handleMessageClosed(context, message);
     }
 
-    private static void setSpinnerVisibility(int visibility){
-        if (wv == null){
+    private static void setSpinnerVisibility(int visibility) {
+        if (wv == null) {
             return;
         }
         wv.post(new Runnable() {
             @Override
             public void run() {
-                if (spinner != null){
+                if (spinner != null) {
                     spinner.setVisibility(visibility);
                 }
             }
         });
     }
 
-    private static void sendToClient(String type, JSONObject data){
-        if (wv == null){
+    private static void sendToClient(String type, JSONObject data) {
+        if (wv == null) {
             return;
         }
         wv.post(new Runnable() {
             @Override
             public void run() {
                 JSONObject j = new JSONObject();
-                try{
+                try {
                     j.put("data", data);
                     j.put("type", type);
-                }
-                catch(JSONException e){
+                } catch (JSONException e) {
                     Log.d(TAG, "Could not create client message");
                     return;
                 }
 
-                String script = "window.postHostMessage("+j.toString()+")";
+                String script = "window.postHostMessage(" + j.toString() + ")";
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                     wv.evaluateJavascript(script, null);
@@ -325,12 +320,12 @@ class InAppMessagePresenter {
         });
     }
 
-    static void maybeCloseDialog(Activity stoppedActivity){
-        if (dialog == null){
+    static void maybeCloseDialog(Activity stoppedActivity) {
+        if (dialog == null) {
             return;
         }
         Activity dialogActivity = getDialogActivity(dialog.getContext());
-        if (stoppedActivity.hashCode() == dialogActivity.hashCode()){
+        if (stoppedActivity.hashCode() == dialogActivity.hashCode()) {
             closeDialog(stoppedActivity);
         }
     }
@@ -339,15 +334,15 @@ class InAppMessagePresenter {
         if (cont == null)
             return null;
         else if (cont instanceof Activity)
-            return (Activity)cont;
+            return (Activity) cont;
         else if (cont instanceof ContextWrapper)
-            return getDialogActivity(((ContextWrapper)cont).getBaseContext());
+            return getDialogActivity(((ContextWrapper) cont).getBaseContext());
 
         return null;
     }
 
-    private static void closeDialog(Activity dialogActivity){
-        if (dialog != null){
+    private static void closeDialog(Activity dialogActivity) {
+        if (dialog != null) {
             unsetStatusBarColorForDialog(dialogActivity);
             dialog.setOnKeyListener(null);
             dialog.dismiss();
@@ -358,12 +353,12 @@ class InAppMessagePresenter {
     }
 
     @UiThread
-    private static void setStatusBarColorForDialog(Activity currentActivity){
-        if (currentActivity == null){
+    private static void setStatusBarColorForDialog(Activity currentActivity) {
+        if (currentActivity == null) {
             return;
         }
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP){
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return;
         }
 
@@ -378,10 +373,9 @@ class InAppMessagePresenter {
         window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
         int statusBarColor;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             statusBarColor = currentActivity.getResources().getColor(R.color.statusBarColorForNotch, null);
-        }
-        else{
+        } else {
             statusBarColor = currentActivity.getResources().getColor(R.color.statusBarColorForNotch);
         }
 
@@ -389,12 +383,12 @@ class InAppMessagePresenter {
     }
 
     @AnyThread
-    private static void unsetStatusBarColorForDialog(Activity dialogActivity){
-        if (dialogActivity == null){
+    private static void unsetStatusBarColorForDialog(Activity dialogActivity) {
+        if (dialogActivity == null) {
             return;
         }
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP){
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return;
         }
 
@@ -405,11 +399,11 @@ class InAppMessagePresenter {
                 Window window = dialogActivity.getWindow();
                 window.setStatusBarColor(prevStatusBarColor);
 
-                if (prevFlagTranslucentStatus){
+                if (prevFlagTranslucentStatus) {
                     window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
                 }
 
-                if (!prevFlagDrawsSystemBarBackgrounds){
+                if (!prevFlagDrawsSystemBarBackgrounds) {
                     window.clearFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
                 }
             }
@@ -417,12 +411,12 @@ class InAppMessagePresenter {
     }
 
 
-    private static void showWebView(@NonNull Activity currentActivity){
+    private static void showWebView(@NonNull Activity currentActivity) {
         currentActivity.runOnUiThread(new Runnable() {
             @SuppressLint("SetJavaScriptEnabled")
             @Override
             public void run() {
-                if (dialog != null){
+                if (dialog != null) {
                     return;
                 }
 
@@ -435,7 +429,7 @@ class InAppMessagePresenter {
                     dialog = new Dialog(currentActivity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
 
                     Window window = dialog.getWindow();
-                    if (window != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P){
+                    if (window != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                         WindowManager.LayoutParams windowAttributes = dialog.getWindow().getAttributes();
                         windowAttributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
 
@@ -469,7 +463,7 @@ class InAppMessagePresenter {
 
                     WebSettings settings = wv.getSettings();
                     settings.setJavaScriptEnabled(true);
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1){
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                         settings.setMediaPlaybackRequiresUserGesture(false);
                     }
 
@@ -518,8 +512,7 @@ class InAppMessagePresenter {
                     });
 
                     wv.loadUrl(IN_APP_RENDERER_URL);
-                }
-                catch(Exception e){
+                } catch (Exception e) {
                     Kumulos.log(TAG, e.getMessage());
                 }
             }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
@@ -428,12 +428,7 @@ class InAppMessageService {
                     Date readAt = InAppContract.getNullableDate(cursor, InAppContract.InAppMessageTable.COL_READ_AT);
                     JSONObject inbox = InAppContract.getNullableJsonObject(cursor, InAppContract.InAppMessageTable.COL_INBOX_CONFIG_JSON);
 
-                    InAppMessage m = new InAppMessage();
-                    m.setInAppId(inAppId);
-                    m.setContent(new JSONObject(content));
-                    m.setPresentedWhen(presentedWhen);
-                    m.setReadAt(readAt);
-                    m.setInbox(inbox);
+                    InAppMessage m = new InAppMessage(inAppId, presentedWhen, new JSONObject(content), inbox, readAt);
                     itemsToPresent.add(m);
                 }
                 cursor.close();

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
@@ -183,10 +183,10 @@ class InAppMessageService {
         int id = message.getInAppId();
 
         boolean markedRead = false;
-        if (message.getReadAt() == null){
+        if (message.getReadAt() == null) {
             markedRead = markInboxItemRead(context, id, false);
         }
-        if (message.getInbox() != null){
+        if (message.getInbox() != null) {
             KumulosInApp.maybeRunInboxUpdatedHandler(markedRead);
         }
 
@@ -297,7 +297,7 @@ class InAppMessageService {
         final Future<Boolean> future = Kumulos.executorService.submit(task);
 
         Boolean result = true;
-        if (shouldWaitForResult){
+        if (shouldWaitForResult) {
             try {
                 result = future.get();
             } catch (InterruptedException | ExecutionException ex) {
@@ -305,7 +305,7 @@ class InAppMessageService {
             }
         }
 
-        if (!result){
+        if (!result) {
             return result;
         }
 
@@ -328,17 +328,17 @@ class InAppMessageService {
         List<InAppInboxItem> inboxItems = readInboxItems(context);
         boolean result = true;
         boolean inboxNeedsUpdate = false;
-        for(InAppInboxItem item: inboxItems){
-            if (item.isRead()){
+        for (InAppInboxItem item : inboxItems) {
+            if (item.isRead()) {
                 continue;
             }
 
             boolean success = markInboxItemRead(context, item.getId(), true);
-            if (success && !inboxNeedsUpdate){
+            if (success && !inboxNeedsUpdate) {
                 inboxNeedsUpdate = true;
             }
 
-            if (!success){
+            if (!success) {
                 result = false;
             }
         }

--- a/kumulos/src/main/java/com/kumulos/android/InAppSaveResult.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppSaveResult.java
@@ -6,11 +6,13 @@ class InAppSaveResult {
     List<InAppMessage> itemsToPresent;
     List<Integer> deliveredIds;
     List<Integer> deletedIds;
+    boolean inboxUpdated;
 
-    InAppSaveResult(List<InAppMessage> itemsToPresent, List<Integer> deliveredIds, List<Integer> deletedIds) {
+    InAppSaveResult(List<InAppMessage> itemsToPresent, List<Integer> deliveredIds, List<Integer> deletedIds, boolean inboxUpdated) {
         this.itemsToPresent = itemsToPresent;
         this.deliveredIds = deliveredIds;
         this.deletedIds = deletedIds;
+        this.inboxUpdated = inboxUpdated;
     }
 
     List<InAppMessage> getItemsToPresent() {
@@ -24,4 +26,6 @@ class InAppSaveResult {
     List<Integer> getDeletedIds() {
         return deletedIds;
     }
+
+    boolean wasInboxUpdated() { return inboxUpdated; }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppSaveResult.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppSaveResult.java
@@ -27,5 +27,7 @@ class InAppSaveResult {
         return deletedIds;
     }
 
-    boolean wasInboxUpdated() { return inboxUpdated; }
+    boolean wasInboxUpdated() {
+        return inboxUpdated;
+    }
 }

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -16,7 +16,7 @@ public class KumulosInApp {
     static InAppDeepLinkHandlerInterface inAppDeepLinkHandler = null;
     static Application application;
 
-    public enum InboxMessagePresentationResult{
+    public enum InboxMessagePresentationResult {
         FAILED,
         FAILED_EXPIRED,
         PRESENTED
@@ -25,6 +25,7 @@ public class KumulosInApp {
     public interface InAppInboxUpdatedHandler extends Runnable {
         void run();
     }
+
     static InAppInboxUpdatedHandler inboxUpdatedHandler;
 
     public interface InAppInboxSummaryHandler {
@@ -34,30 +35,30 @@ public class KumulosInApp {
     //==============================================================================================
     //-- Public APIs
 
-    public static List<InAppInboxItem> getInboxItems(Context context){
+    public static List<InAppInboxItem> getInboxItems(Context context) {
         boolean inAppEnabled = isInAppEnabled();
-        if (!inAppEnabled){
+        if (!inAppEnabled) {
             throw new RuntimeException("Kumulos: It is only possible to read In App inbox if In App messaging is enabled");
         }
 
         return InAppMessageService.readInboxItems(context);
     }
 
-    public static InboxMessagePresentationResult presentInboxMessage(Context context, InAppInboxItem item)  {
+    public static InboxMessagePresentationResult presentInboxMessage(Context context, InAppInboxItem item) {
         boolean inAppEnabled = isInAppEnabled();
-        if (!inAppEnabled){
+        if (!inAppEnabled) {
             throw new RuntimeException("Kumulos: It is only possible to present In App inbox if In App messaging is enabled");
         }
 
         return InAppMessageService.presentMessage(context, item);
     }
 
-    public static boolean deleteMessageFromInbox(Context context, InAppInboxItem item){
+    public static boolean deleteMessageFromInbox(Context context, InAppInboxItem item) {
         return InAppMessageService.deleteMessageFromInbox(context, item.getId());
     }
 
-    public static boolean markAsRead(Context context, InAppInboxItem item){
-        if (item.isRead()){
+    public static boolean markAsRead(Context context, InAppInboxItem item) {
+        if (item.isRead()) {
             return false;
         }
 
@@ -67,7 +68,7 @@ public class KumulosInApp {
         return res;
     }
 
-    public static boolean markAllInboxItemsAsRead(Context context){
+    public static boolean markAllInboxItemsAsRead(Context context) {
         return InAppMessageService.markAllInboxItemsAsRead(context);
     }
 
@@ -75,7 +76,7 @@ public class KumulosInApp {
         KumulosInApp.inboxUpdatedHandler = inboxUpdatedHandler;
     }
 
-    public static void getInboxSummaryAsync(Context context, @Nullable InAppInboxSummaryHandler inboxSummaryHandler){
+    public static void getInboxSummaryAsync(Context context, @Nullable InAppInboxSummaryHandler inboxSummaryHandler) {
         Runnable task = new InAppContract.ReadInboxSummaryRunnable(context, inboxSummaryHandler);
         Kumulos.executorService.submit(task);
     }
@@ -84,16 +85,16 @@ public class KumulosInApp {
     /**
      * Used to update in-app consent when enablement strategy is EXPLICIT_BY_USER
      *
-     *   @param consentGiven
+     * @param consentGiven
      */
 
-    public static void updateConsentForUser(boolean consentGiven){
-        if (Kumulos.getConfig().getInAppConsentStrategy() != KumulosConfig.InAppConsentStrategy.EXPLICIT_BY_USER){
+    public static void updateConsentForUser(boolean consentGiven) {
+        if (Kumulos.getConfig().getInAppConsentStrategy() != KumulosConfig.InAppConsentStrategy.EXPLICIT_BY_USER) {
             throw new RuntimeException("Kumulos: It is only possible to update In App consent for user if consent strategy is set to EXPLICIT_BY_USER");
         }
 
         boolean inAppWasEnabled = isInAppEnabled();
-        if (consentGiven != inAppWasEnabled){
+        if (consentGiven != inAppWasEnabled) {
             updateInAppEnablementFlags(consentGiven);
             toggleInAppMessageMonitoring(consentGiven);
         }
@@ -101,27 +102,27 @@ public class KumulosInApp {
 
     /**
      * Allows setting the handler you want to use for in-app deep-link buttons
+     *
      * @param handler
      */
     public static void setDeepLinkHandler(InAppDeepLinkHandlerInterface handler) {
         inAppDeepLinkHandler = handler;
     }
 
-    
+
     //==============================================================================================
     //-- Internal Helpers
 
-    static void initialize(Application application, KumulosConfig currentConfig){
+    static void initialize(Application application, KumulosConfig currentConfig) {
         KumulosInApp.application = application;
 
         KumulosConfig.InAppConsentStrategy strategy = currentConfig.getInAppConsentStrategy();
         boolean inAppEnabled = isInAppEnabled();
 
-        if (strategy == KumulosConfig.InAppConsentStrategy.AUTO_ENROLL && !inAppEnabled){
+        if (strategy == KumulosConfig.InAppConsentStrategy.AUTO_ENROLL && !inAppEnabled) {
             inAppEnabled = true;
             updateInAppEnablementFlags(true);
-        }
-        else if (strategy == null && inAppEnabled){
+        } else if (strategy == null && inAppEnabled) {
             inAppEnabled = false;
             updateInAppEnablementFlags(false);
             InAppMessageService.clearAllMessages(application);
@@ -131,17 +132,17 @@ public class KumulosInApp {
         toggleInAppMessageMonitoring(inAppEnabled);
     }
 
-    private static void updateInAppEnablementFlags(boolean enabled){
+    private static void updateInAppEnablementFlags(boolean enabled) {
         updateRemoteInAppEnablementFlag(enabled);
         updateLocalInAppEnablementFlag(enabled);
     }
 
-    static boolean isInAppEnabled(){
+    static boolean isInAppEnabled() {
         SharedPreferences prefs = application.getSharedPreferences(SharedPrefs.PREFS_FILE, Context.MODE_PRIVATE);
         return prefs.getBoolean(SharedPrefs.IN_APP_ENABLED, false);
     }
 
-    private static void updateRemoteInAppEnablementFlag(boolean enabled){
+    private static void updateRemoteInAppEnablementFlag(boolean enabled) {
         try {
             JSONObject params = new JSONObject().put("consented", enabled);
 
@@ -151,7 +152,7 @@ public class KumulosInApp {
         }
     }
 
-    private static void updateLocalInAppEnablementFlag(boolean enabled){
+    private static void updateLocalInAppEnablementFlag(boolean enabled) {
         SharedPreferences prefs = application.getSharedPreferences(SharedPrefs.PREFS_FILE, Context.MODE_PRIVATE);
 
         SharedPreferences.Editor editor = prefs.edit();
@@ -159,44 +160,41 @@ public class KumulosInApp {
         editor.apply();
     }
 
-    private static void clearLastSyncTime(Context context){
+    private static void clearLastSyncTime(Context context) {
         SharedPreferences prefs = context.getSharedPreferences(SharedPrefs.PREFS_FILE, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
         editor.remove(SharedPrefs.IN_APP_LAST_SYNC_TIME);
         editor.apply();
     }
 
-    static void handleInAppUserChange(Context context, KumulosConfig currentConfig){
+    static void handleInAppUserChange(Context context, KumulosConfig currentConfig) {
         InAppMessageService.clearAllMessages(context);
         clearLastSyncTime(context);
 
         KumulosConfig.InAppConsentStrategy strategy = currentConfig.getInAppConsentStrategy();
-        if (strategy == KumulosConfig.InAppConsentStrategy.EXPLICIT_BY_USER){
+        if (strategy == KumulosConfig.InAppConsentStrategy.EXPLICIT_BY_USER) {
             updateLocalInAppEnablementFlag(false);
             toggleInAppMessageMonitoring(false);
-        }
-        else if (strategy == KumulosConfig.InAppConsentStrategy.AUTO_ENROLL){
+        } else if (strategy == KumulosConfig.InAppConsentStrategy.AUTO_ENROLL) {
             updateRemoteInAppEnablementFlag(true);
 
             fetchMessages();
-        }
-        else if (strategy == null){
+        } else if (strategy == null) {
             updateRemoteInAppEnablementFlag(false);
         }
     }
 
-    private static void toggleInAppMessageMonitoring(boolean enabled){
-        if (enabled){
+    private static void toggleInAppMessageMonitoring(boolean enabled) {
+        if (enabled) {
             InAppSyncWorker.startPeriodicFetches(application);
 
             fetchMessages();
-        }
-        else {
+        } else {
             InAppSyncWorker.cancelPeriodicFetches(application);
         }
     }
 
-    private static void fetchMessages(){
+    private static void fetchMessages() {
         Kumulos.executorService.submit(new Runnable() {
             @Override
             public void run() {
@@ -205,13 +203,13 @@ public class KumulosInApp {
         });
     }
 
-    static void maybeRunInboxUpdatedHandler(boolean inboxNeedsUpdate){
-        if (!inboxNeedsUpdate || inboxUpdatedHandler == null){
+    static void maybeRunInboxUpdatedHandler(boolean inboxNeedsUpdate) {
+        if (!inboxNeedsUpdate || inboxUpdatedHandler == null) {
             return;
         }
 
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
-        if (currentActivity == null){
+        if (currentActivity == null) {
             return;
         }
 

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -22,7 +22,7 @@ public class KumulosInApp {
         PRESENTED
     }
 
-    public interface InAppInboxUpdatedHandler {
+    public interface InAppInboxUpdatedHandler extends Runnable {
         void run();
     }
     static InAppInboxUpdatedHandler inboxUpdatedHandler;
@@ -215,11 +215,6 @@ public class KumulosInApp {
             return;
         }
 
-        currentActivity.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                inboxUpdatedHandler.run();
-            }
-        });
+        currentActivity.runOnUiThread(inboxUpdatedHandler);
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -28,7 +28,7 @@ public class KumulosInApp {
     static InAppInboxUpdatedHandler inboxUpdatedHandler;
 
     public interface InAppInboxSummaryHandler {
-        void run(InAppInboxSummaryInfo summary);
+        void run(InAppInboxSummary summary);
     }
 
     //==============================================================================================

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -35,6 +35,11 @@ public class KumulosInApp {
     //==============================================================================================
     //-- Public APIs
 
+    /**
+     * Returns up to 50 non-expired in-app messages stored in inbox
+     *
+     * @param context
+     */
     public static List<InAppInboxItem> getInboxItems(Context context) {
         boolean inAppEnabled = isInAppEnabled();
         if (!inAppEnabled) {
@@ -44,6 +49,12 @@ public class KumulosInApp {
         return InAppMessageService.readInboxItems(context);
     }
 
+    /**
+     * Presents selected inbox item
+     *
+     * @param context
+     * @param item inbox item to present
+     */
     public static InboxMessagePresentationResult presentInboxMessage(Context context, InAppInboxItem item) {
         boolean inAppEnabled = isInAppEnabled();
         if (!inAppEnabled) {
@@ -53,10 +64,22 @@ public class KumulosInApp {
         return InAppMessageService.presentMessage(context, item);
     }
 
+    /**
+     * Deletes selected inbox item
+     *
+     * @param context
+     * @param item inbox item to delete
+     */
     public static boolean deleteMessageFromInbox(Context context, InAppInboxItem item) {
         return InAppMessageService.deleteMessageFromInbox(context, item.getId());
     }
 
+    /**
+     * Marks selected inbox item as read
+     *
+     * @param context
+     * @param item inbox item to mark as read
+     */
     public static boolean markAsRead(Context context, InAppInboxItem item) {
         if (item.isRead()) {
             return false;
@@ -68,14 +91,32 @@ public class KumulosInApp {
         return res;
     }
 
+    /**
+     * Marks all inbox items as read.
+     *
+     * @param context
+     */
     public static boolean markAllInboxItemsAsRead(Context context) {
         return InAppMessageService.markAllInboxItemsAsRead(context);
     }
 
+    /**
+     * Set a handler to run when inbox has changes which might be relevant for presentation.
+     * These concern messages with inbox set: fetched new message, message evicted, message opened, message deleted, message marked as read.
+     * Handler runs on UI thread.
+     *
+     * @param inboxUpdatedHandler handler
+     */
     public static void setOnInboxUpdated(@Nullable InAppInboxUpdatedHandler inboxUpdatedHandler) {
         KumulosInApp.inboxUpdatedHandler = inboxUpdatedHandler;
     }
 
+    /**
+     * Asynchronously runs inbox summary handler on UI thread. Handler receives a single argument InAppInboxSummary
+     *
+     * @param context
+     * @param inboxSummaryHandler handler
+     */
     public static void getInboxSummaryAsync(Context context, @Nullable InAppInboxSummaryHandler inboxSummaryHandler) {
         Runnable task = new InAppContract.ReadInboxSummaryRunnable(context, inboxSummaryHandler);
         Kumulos.executorService.submit(task);

--- a/kumulos/src/main/java/com/kumulos/android/PushMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushMessage.java
@@ -20,19 +20,39 @@ public final class PushMessage implements Parcelable {
     private static final int DEEP_LINK_TYPE_IN_APP = 1;
     public static final String TAG = PushMessage.class.getName();
 
-    private int id;
-    private String title;
-    private String message;
+    private final int id;
+    private final @Nullable
+    String title;
+    private final @Nullable
+    String message;
     private JSONObject data;
-    private long timeSent;
-    private Uri url;
-    private boolean runBackgroundHandler;
-    private int tickleId;
-    private String pictureUrl;
-    private JSONArray buttons;
-    private String sound;
+    private final long timeSent;
+    private @Nullable
+    Uri url;
+    private final boolean runBackgroundHandler;
+    private final int tickleId;
+    private final @Nullable
+    String pictureUrl;
+    private @Nullable
+    JSONArray buttons;
+    private final @Nullable
+    String sound;
+    private @Nullable
+    String collapseKey;
 
-    /** package */ PushMessage(int id, @Nullable String title, @Nullable String message, JSONObject data, long timeSent, @Nullable Uri url, boolean runBackgroundHandler, @Nullable String pictureUrl, @Nullable JSONArray buttons, @Nullable String sound) {
+    /**
+     * package
+     */
+    PushMessage(int id,
+                @Nullable String title,
+                @Nullable String message,
+                JSONObject data, long timeSent,
+                @Nullable Uri url,
+                boolean runBackgroundHandler,
+                @Nullable String pictureUrl,
+                @Nullable JSONArray buttons,
+                @Nullable String sound,
+                @Nullable String collapseKey) {
         this.id = id;
         this.title = title;
         this.message = message;
@@ -44,6 +64,7 @@ public final class PushMessage implements Parcelable {
         this.pictureUrl = pictureUrl;
         this.buttons = buttons;
         this.sound = sound;
+        this.collapseKey = collapseKey;
     }
 
     private PushMessage(Parcel in) {
@@ -79,25 +100,25 @@ public final class PushMessage implements Parcelable {
         }
 
         sound = in.readString();
+        collapseKey = in.readString();
     }
 
-    private Integer getTickleId(JSONObject data){
+    private Integer getTickleId(JSONObject data) {
         JSONObject deepLink = data.optJSONObject("k.deepLink");
 
-        if (deepLink == null){
+        if (deepLink == null) {
             return -1;
         }
 
         int linkType = deepLink.optInt("type", -1);
 
-        if (linkType != DEEP_LINK_TYPE_IN_APP){
+        if (linkType != DEEP_LINK_TYPE_IN_APP) {
             return -1;
         }
 
-        try{
+        try {
             return deepLink.getJSONObject("data").getInt("id");
-        }
-        catch(JSONException e){
+        } catch (JSONException e) {
             Kumulos.log(TAG, e.toString());
             return -1;
         }
@@ -137,17 +158,20 @@ public final class PushMessage implements Parcelable {
         dest.writeString(pictureUrl);
         dest.writeString(buttonsString);
         dest.writeString(sound);
+        dest.writeString(collapseKey);
     }
 
     public int getId() {
         return id;
     }
 
-    public String getTitle() {
+    public @Nullable
+    String getTitle() {
         return title;
     }
 
-    public String getMessage() {
+    public @Nullable
+    String getMessage() {
         return message;
     }
 
@@ -178,18 +202,23 @@ public final class PushMessage implements Parcelable {
 
 
     @Nullable
-    public String getPictureUrl(){
+    public String getPictureUrl() {
         return this.pictureUrl;
     }
 
     @Nullable
-    public JSONArray getButtons(){
+    public JSONArray getButtons() {
         return this.buttons;
     }
 
     @Nullable
-    public String getSound(){
+    public String getSound() {
         return this.sound;
+    }
+
+    @Nullable
+    public String getCollapseKey() {
+        return this.collapseKey;
     }
 
 }

--- a/kumulos/src/main/java/com/kumulos/android/PushMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushMessage.java
@@ -37,7 +37,7 @@ public final class PushMessage implements Parcelable {
     JSONArray buttons;
     private final @Nullable
     String sound;
-    private @Nullable
+    private final @Nullable
     String collapseKey;
 
     /**


### PR DESCRIPTION
### Description of Changes

1) `KumulosInApp.setOnInboxUpdated(() -> { });`. Callback runs every time there are changes relevant for inbox presentation. These are: 
- markRead
- markAllRead
- messageOpened (for this to work properly need to add `readAt` and `inbox` to every message in presentation queue)
- deleteInboxMessage
- sync
- eviction

The callback is run on UI thread. It is a responsibility of users to make sure `getInboxItems` (which is sync) they might wish to run afterwards is not blocking UI. 

Edge cases:
- inbox message drops out of availability window. It stays in inbox until evicted with next sync. This is very unlikely and badge and inbox both lag and then both get updated. If try to open such message get result EXPIRED as before
-  If we manually set inbox to null in db (e.g. customer request), inbox will not refresh. To make it refresh would need to set inbox expiry and message expiry.

2) `getInboxSummary` with async callback, e.g.
```
KumulosInApp.getInboxSummaryAsync(MainActivity.this, (InAppInboxSummaryInfo summary) -> {
     summary.getTotalCount();
     summary.getUnreadCount(); 
});
```
3) expose `sentAt` and `data` on inbox items
3)  expose `collapseKey` on PushMessage. CollapseKey is used by FCM/HCM for not delivered messages (e.g. if offline, new with the same key replaces old)





### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
