### PR TITLE
Okhttp issues on android 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.6.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.6.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.6.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.6.1'
 }
 ```
 

--- a/kumulos/build.gradle
+++ b/kumulos/build.gradle
@@ -31,7 +31,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.12'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'ch.acra:acra-http:5.5.0'
     implementation 'org.codehaus.jackson:jackson-mapper-asl:1.8.5'
     implementation 'androidx.work:work-runtime:2.5.0'


### PR DESCRIPTION
### Description of Changes

Crashes due to deprecation of methods used by okhttp

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
