### PR TITLE
Pass webInstallId query parameter when reading deep link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.6.2'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.6.2'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.6.3'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.6.3'
 }
 ```
 

--- a/kumulos/src/main/java/com/kumulos/android/DeferredDeepLinkHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/DeferredDeepLinkHelper.java
@@ -184,8 +184,11 @@ public class DeferredDeepLinkHelper {
                 .get()
                 .build();
 
-        this.makeNetworkRequest(context, httpClient, request, url, wasDeferred);
-
+        try {
+            this.makeNetworkRequest(context, httpClient, request, new URL(requestUrl), wasDeferred);
+        } catch (MalformedURLException e) {
+            Log.d(TAG, "Could not create correct URL: " + e.getMessage());
+        }
     }
 
     private void makeNetworkRequest(Context context, OkHttpClient httpClient, Request request, URL url, boolean wasDeferred) {

--- a/kumulos/src/main/java/com/kumulos/android/DeferredDeepLinkHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/DeferredDeepLinkHelper.java
@@ -9,7 +9,6 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
-import android.util.Log;
 import android.webkit.URLUtil;
 
 import androidx.annotation.Nullable;
@@ -18,11 +17,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Map;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -32,7 +28,6 @@ import static android.content.Context.CLIPBOARD_SERVICE;
 
 public class DeferredDeepLinkHelper {
     private static final String BASE_URL = "https://links.kumulos.com";
-    private static final String TAG = DeferredDeepLinkHelper.class.getName();
 
     /* package */ DeferredDeepLinkHelper() {
     }
@@ -165,14 +160,9 @@ public class DeferredDeepLinkHelper {
 
         String slug = Uri.encode(url.getPath().replaceAll("/$|^/", ""));
         String params = "?wasDeferred=" + (wasDeferred ? 1 : 0);
-        try {
-            Map<String, String> map = HttpUtils.splitQuery(url);
-            String webInstallId = map.get("webInstallId");
-            if (webInstallId != null) {
-                params = params + "&webInstallId=" + webInstallId;
-            }
-        } catch (UnsupportedEncodingException e) {
-            Log.d(TAG, "Could not decode query parameters: " + e.getMessage());
+        String query = url.getQuery();
+        if (query != null){
+           params = params + "&" + query;
         }
 
         String requestUrl = DeferredDeepLinkHelper.BASE_URL + "/v1/deeplinks/" + slug + params;

--- a/kumulos/src/main/java/com/kumulos/android/DeferredDeepLinkHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/DeferredDeepLinkHelper.java
@@ -20,6 +20,7 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Map;
 
@@ -183,11 +184,12 @@ public class DeferredDeepLinkHelper {
                 .addHeader("Content-Type", "application/json")
                 .get()
                 .build();
-
+        
         try {
-            this.makeNetworkRequest(context, httpClient, request, new URL(requestUrl), wasDeferred);
-        } catch (MalformedURLException e) {
-            Log.d(TAG, "Could not create correct URL: " + e.getMessage());
+            URL noParamsUrl = new URL(HttpUtils.getUrlWithoutParameters(url));
+            this.makeNetworkRequest(context, httpClient, request, noParamsUrl , wasDeferred);
+        } catch (URISyntaxException | MalformedURLException e) {
+            Log.d(TAG, "Could not format URL: " + e.getMessage());
         }
     }
 

--- a/kumulos/src/main/java/com/kumulos/android/DeferredDeepLinkHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/DeferredDeepLinkHelper.java
@@ -184,13 +184,8 @@ public class DeferredDeepLinkHelper {
                 .addHeader("Content-Type", "application/json")
                 .get()
                 .build();
-        
-        try {
-            URL noParamsUrl = new URL(HttpUtils.getUrlWithoutParameters(url));
-            this.makeNetworkRequest(context, httpClient, request, noParamsUrl , wasDeferred);
-        } catch (URISyntaxException | MalformedURLException e) {
-            Log.d(TAG, "Could not format URL: " + e.getMessage());
-        }
+
+        this.makeNetworkRequest(context, httpClient, request, url, wasDeferred);
     }
 
     private void makeNetworkRequest(Context context, OkHttpClient httpClient, Request request, URL url, boolean wasDeferred) {

--- a/kumulos/src/main/java/com/kumulos/android/HttpUtils.java
+++ b/kumulos/src/main/java/com/kumulos/android/HttpUtils.java
@@ -1,10 +1,7 @@
 package com.kumulos.android;
 
 import org.json.JSONObject;
-
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.LinkedHashMap;
@@ -41,14 +38,5 @@ class HttpUtils {
             map.put(URLDecoder.decode(pair.substring(0, idx), "UTF-8"), URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
         }
         return map;
-    }
-
-    static String getUrlWithoutParameters(URL url) throws URISyntaxException {
-        URI uri = url.toURI();
-        return new URI(uri.getScheme(),
-                uri.getAuthority(),
-                uri.getPath(),
-                null,
-                uri.getFragment()).toString();
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/HttpUtils.java
+++ b/kumulos/src/main/java/com/kumulos/android/HttpUtils.java
@@ -1,12 +1,6 @@
 package com.kumulos.android;
 
 import org.json.JSONObject;
-import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -24,19 +18,5 @@ class HttpUtils {
                 .url(url)
                 .addHeader(Kumulos.KEY_AUTH_HEADER, Kumulos.authHeader)
                 .addHeader("Accept", "application/json");
-    }
-
-    static Map<String, String> splitQuery(URL url) throws UnsupportedEncodingException {
-        Map<String, String> map = new LinkedHashMap<String, String>();
-        String query = url.getQuery();
-        if (query == null){
-            return map;
-        }
-        String[] pairs = query.split("&");
-        for (String pair : pairs) {
-            int idx = pair.indexOf("=");
-            map.put(URLDecoder.decode(pair.substring(0, idx), "UTF-8"), URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
-        }
-        return map;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/HttpUtils.java
+++ b/kumulos/src/main/java/com/kumulos/android/HttpUtils.java
@@ -2,6 +2,12 @@ package com.kumulos.android;
 
 import org.json.JSONObject;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -21,4 +27,14 @@ class HttpUtils {
                 .addHeader("Accept", "application/json");
     }
 
+    static Map<String, String> splitQuery(URL url) throws UnsupportedEncodingException {
+        Map<String, String> map = new LinkedHashMap<String, String>();
+        String query = url.getQuery();
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+            int idx = pair.indexOf("=");
+            map.put(URLDecoder.decode(pair.substring(0, idx), "UTF-8"), URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
+        }
+        return map;
+    }
 }

--- a/kumulos/src/main/java/com/kumulos/android/HttpUtils.java
+++ b/kumulos/src/main/java/com/kumulos/android/HttpUtils.java
@@ -3,6 +3,8 @@ package com.kumulos.android;
 import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.LinkedHashMap;
@@ -30,11 +32,23 @@ class HttpUtils {
     static Map<String, String> splitQuery(URL url) throws UnsupportedEncodingException {
         Map<String, String> map = new LinkedHashMap<String, String>();
         String query = url.getQuery();
+        if (query == null){
+            return map;
+        }
         String[] pairs = query.split("&");
         for (String pair : pairs) {
             int idx = pair.indexOf("=");
             map.put(URLDecoder.decode(pair.substring(0, idx), "UTF-8"), URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
         }
         return map;
+    }
+
+    static String getUrlWithoutParameters(URL url) throws URISyntaxException {
+        URI uri = url.toURI();
+        return new URI(uri.getScheme(),
+                uri.getAuthority(),
+                uri.getPath(),
+                null,
+                uri.getFragment()).toString();
     }
 }


### PR DESCRIPTION
### Description of Changes

If deep link is opened by clicking a banner (WebSDK) extra query parameter is present on the copied URL. Pass it to API when reading deep link in order to track conversion.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
