### PR TITLE
SDK parity and inbox image APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.6.4'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.6.4'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.7.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.7.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.6.3'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.6.3'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.6.4'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.6.4'
 }
 ```
 

--- a/kumulos/build.gradle
+++ b/kumulos/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'maven-publish'
 def releaseVersion = System.getenv("RELEASE_VERSION") as String ?: "0.0.0"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion '29.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
 
         // https://issuetracker.google.com/issues/158695880
         buildConfigField 'String', 'VERSION_NAME', "\"$releaseVersion\""

--- a/kumulos/build.gradle
+++ b/kumulos/build.gradle
@@ -29,13 +29,15 @@ android {
     }
 }
 
+
+def firebaseMessagingVersionRange = '[19.0.0, 22.99.99]'
 dependencies {
     testImplementation 'junit:junit:4.12'
     implementation 'com.squareup.okhttp3:okhttp:3.12.13'
     implementation 'ch.acra:acra-http:5.5.0'
     implementation 'org.codehaus.jackson:jackson-mapper-asl:1.8.5'
     implementation 'androidx.work:work-runtime:2.5.0'
-    implementation 'com.google.firebase:firebase-messaging:21.0.1'
+    implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersionRange"
     compileOnly 'com.huawei.hms:push:4.0.3.300'
 }
 

--- a/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.work.Constraints;
@@ -422,6 +423,7 @@ import androidx.work.WorkManager;
         public void onActivitySaveInstanceState(Activity activity, Bundle outState) {  /* noop */ }
 
         @Override
+        @MainThread
         public void onActivityDestroyed(Activity activity) {
             InAppMessagePresenter.maybeCloseDialog(activity);
 

--- a/kumulos/src/main/java/com/kumulos/android/ImplementationUtil.java
+++ b/kumulos/src/main/java/com/kumulos/android/ImplementationUtil.java
@@ -21,7 +21,7 @@ final class ImplementationUtil {
 
     enum FirebaseMessagingApi {
         UNKNOWN,
-        DEPRECATED,  //FirebaseMessaging [19.0.0, 22.0.0)
+        DEPRECATED_1,  //FirebaseMessaging [19.0.0, 22.0.0)
         LATEST   //FirebaseMessaging [21.0.0, 22.99.99]
     }
 
@@ -36,8 +36,8 @@ final class ImplementationUtil {
             if (ConnectionResult.SUCCESS == result) {
                 availableMessagingApi = MessagingApi.FCM;
 
-                if (this.canLoadClass("com.google.firebase.iid.FirebaseInstanceId")){
-                    firebaseMessagingApi = FirebaseMessagingApi.DEPRECATED;
+                if (canLoadClass("com.google.firebase.iid.FirebaseInstanceId")){
+                    firebaseMessagingApi = FirebaseMessagingApi.DEPRECATED_1;
                 }
                 else if (this.hasLatestFirebaseMessaging()){
                     firebaseMessagingApi = FirebaseMessagingApi.LATEST;

--- a/kumulos/src/main/java/com/kumulos/android/ImplementationUtil.java
+++ b/kumulos/src/main/java/com/kumulos/android/ImplementationUtil.java
@@ -3,7 +3,7 @@ package com.kumulos.android;
 import android.content.Context;
 
 import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.common.GoogleApiAvailabilityLight;
 import com.huawei.hms.api.HuaweiApiAvailability;
 
 import androidx.annotation.NonNull;
@@ -23,8 +23,8 @@ final class ImplementationUtil {
     private ImplementationUtil() {}
 
     private ImplementationUtil(@NonNull Context context) {
-        if (canLoadClass("com.google.android.gms.common.GoogleApiAvailability")) {
-            int result = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context);
+        if (canLoadClass("com.google.android.gms.common.GoogleApiAvailabilityLight")) {
+            int result = GoogleApiAvailabilityLight.getInstance().isGooglePlayServicesAvailable(context);
 
             if (ConnectionResult.SUCCESS == result) {
                 availableMessagingApi = MessagingApi.FCM;

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -423,8 +423,14 @@ class InAppContract {
                     i.setSentAt(sentAt);
                     i.setData(data);
 
-                    i.setTitle(inboxConfig.getString("title"));
-                    i.setSubtitle(inboxConfig.getString("subtitle"));
+                    if (inboxConfig != null){
+                        i.setTitle(inboxConfig.getString("title"));
+                        i.setSubtitle(inboxConfig.getString("subtitle"));
+                        if (!inboxConfig.isNull("imagePath")) {
+                            i.setImagePath(inboxConfig.getString("imagePath"));
+                        }
+                    }
+
                     inboxItems.add(i);
                 }
                 cursor.close();

--- a/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppInboxItem.java
@@ -1,5 +1,7 @@
 package com.kumulos.android;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Date;
 
 import androidx.annotation.NonNull;
@@ -11,6 +13,8 @@ public class InAppInboxItem {
 
     InAppInboxItem() {
     }
+
+    private final int DEFAULT_IMAGE_WIDTH = 300;
 
     private int id;
     private String title;
@@ -26,6 +30,8 @@ public class InAppInboxItem {
     private Date sentAt;
     @Nullable
     private JSONObject data;
+    @Nullable
+    private String imagePath;
 
     public int getId() {
         return id;
@@ -101,5 +107,28 @@ public class InAppInboxItem {
 
     void setData(@Nullable JSONObject data) {
         this.data = data;
+    }
+
+    void setImagePath(@NonNull String imagePath) {
+        this.imagePath = imagePath;
+    }
+
+    public @Nullable
+    URL getImageUrl() {
+        return this.getImageUrl(DEFAULT_IMAGE_WIDTH);
+    }
+
+    public @Nullable
+    URL getImageUrl(int width) {
+        if (width <= 0 || this.imagePath == null){
+            return null;
+        }
+
+        try{
+            return MediaHelper.getCompletePictureUrl(this.imagePath, width);
+        }
+        catch(MalformedURLException e){
+            return null;
+        }
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -367,10 +367,12 @@ class InAppMessagePresenter {
         prevStatusBarColor = window.getStatusBarColor();
 
         int flags = window.getAttributes().flags;
-        prevFlagTranslucentStatus = (flags & WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS) != 0;
-        prevFlagDrawsSystemBarBackgrounds = (flags & WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS) != 0;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            prevFlagTranslucentStatus = (flags & WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS) != 0;
+            window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+        }
 
-        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+        prevFlagDrawsSystemBarBackgrounds = (flags & WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS) != 0;
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
         int statusBarColor;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -6,7 +6,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.ContextWrapper;
-import android.content.DialogInterface;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.os.Build;
@@ -66,6 +65,15 @@ class InAppMessagePresenter {
             return;
         }
 
+        currentActivity.runOnUiThread(() -> presentMessagesOnUiThread(currentActivity, itemsToPresent, tickleIds));
+    }
+
+    @UiThread
+    private static void presentMessagesOnUiThread(Activity currentActivity, List<InAppMessage> itemsToPresent, List<Integer> tickleIds){
+        if (currentActivity == null){
+            return;
+        }
+
         if (itemsToPresent.isEmpty()) {
             if (messageQueue.isEmpty()) {
                 maybeCloseDialog(currentActivity);
@@ -98,6 +106,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static void maybeRefreshFirstMessageInQueue(List<InAppMessage> oldQueue) {
         if (oldQueue.isEmpty()) {
             return;
@@ -110,6 +119,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static void moveTicklesToFront(List<Integer> tickleIds) {
         if (tickleIds == null || tickleIds.isEmpty()) {
             return;
@@ -128,6 +138,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static void addMessagesToQueue(List<InAppMessage> itemsToPresent) {
         for (InAppMessage messageToAppend : itemsToPresent) {
             boolean exists = false;
@@ -144,6 +155,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static void presentMessageToClient() {
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
         if (currentActivity == null) {
@@ -170,20 +182,23 @@ class InAppMessagePresenter {
         sendToClient(HOST_MESSAGE_TYPE_PRESENT_MESSAGE, message.getContent());
     }
 
+    @AnyThread
     static void clientReady(Context context) {
         if (wv == null) {
             return;
         }
 
-        wv.post(new Runnable() {
-            @Override
-            public void run() {
-                maybeSetNotchInsets(context);
-                presentMessageToClient();
+        wv.post(() -> {
+            if (wv == null) {
+                return;
             }
+
+            maybeSetNotchInsets(context);
+            presentMessageToClient();
         });
     }
 
+    @UiThread
     private static void maybeSetNotchInsets(Context context) {
         if (dialog == null) {
             return;
@@ -204,7 +219,7 @@ class InAppMessagePresenter {
             return;
         }
 
-        Pair notchPositions = determineNotchPositions(window, cutoutBoundingRectangles);
+        Pair<Boolean, Boolean> notchPositions = determineNotchPositions(window, cutoutBoundingRectangles);
         float density = context.getResources().getDisplayMetrics().density;
 
         JSONObject notchData = new JSONObject();
@@ -222,6 +237,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static Pair<Boolean, Boolean> determineNotchPositions(Window window, List<Rect> cutoutBoundingRectangles) {
         Display display = window.getWindowManager().getDefaultDisplay();
         DisplayMetrics outMetrics = new DisplayMetrics();
@@ -243,84 +259,85 @@ class InAppMessagePresenter {
             }
         }
 
-        return new Pair<Boolean, Boolean>(hasNotchOnTheLeft, hasNotchOnTheRight);
+        return new Pair<>(hasNotchOnTheLeft, hasNotchOnTheRight);
     }
 
-    static void messageOpened(Context context) {
-        InAppMessageService.handleMessageOpened(context, messageQueue.get(0));
-        setSpinnerVisibility(View.GONE);
+    @AnyThread
+    static void messageOpened(Activity activity) {
+        activity.runOnUiThread(() -> {
+            InAppMessageService.handleMessageOpened(activity, messageQueue.get(0));
+            setSpinnerVisibility(View.GONE);
+        });
     }
 
+    @AnyThread
     static void messageClosed() {
         if (wv == null) {
             return;
         }
 
-        wv.post(new Runnable() {
-            @Override
-            public void run() {
-                InAppMessage message = messageQueue.get(0);
-                messageQueue.remove(0);
-
-                presentMessageToClient();
+        wv.post(() -> {
+            if (wv == null) {
+                return;
             }
+
+            messageQueue.remove(0);
+
+            presentMessageToClient();
         });
     }
 
-    static void closeCurrentMessage(Context context) {
-        if (dialog == null || messageQueue.isEmpty()) {
+    @AnyThread
+    static void closeCurrentMessage(Activity activity) {
+        if (dialog == null  || activity == null) {
             return;
         }
 
-        InAppMessage message = messageQueue.get(0);
+        activity.runOnUiThread(() -> {
+            if (messageQueue.isEmpty()){
+                return;
+            }
+            InAppMessage message = messageQueue.get(0);
 
-        InAppMessagePresenter.sendToClient(HOST_MESSAGE_TYPE_CLOSE_MESSAGE, null);
+            InAppMessagePresenter.sendToClient(HOST_MESSAGE_TYPE_CLOSE_MESSAGE, null);
 
-        InAppMessageService.handleMessageClosed(context, message);
+            InAppMessageService.handleMessageClosed(activity, message);
+        });
     }
 
+    @UiThread
     private static void setSpinnerVisibility(int visibility) {
-        if (wv == null) {
-            return;
+        if (spinner != null){
+            spinner.setVisibility(visibility);
         }
-        wv.post(new Runnable() {
-            @Override
-            public void run() {
-                if (spinner != null) {
-                    spinner.setVisibility(visibility);
-                }
-            }
-        });
     }
 
+    @UiThread
     private static void sendToClient(String type, JSONObject data) {
         if (wv == null) {
             return;
         }
-        wv.post(new Runnable() {
-            @Override
-            public void run() {
-                JSONObject j = new JSONObject();
-                try {
-                    j.put("data", data);
-                    j.put("type", type);
-                } catch (JSONException e) {
-                    Log.d(TAG, "Could not create client message");
-                    return;
-                }
 
-                String script = "window.postHostMessage(" + j.toString() + ")";
+        JSONObject j = new JSONObject();
+        try {
+            j.put("data", data);
+            j.put("type", type);
+        } catch (JSONException e) {
+            Log.d(TAG, "Could not create client message");
+            return;
+        }
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    wv.evaluateJavascript(script, null);
-                } else {
-                    wv.loadUrl("javascript:" + script);
-                }
-            }
-        });
+        String script = "window.postHostMessage(" + j.toString() + ")";
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            wv.evaluateJavascript(script, null);
+        } else {
+            wv.loadUrl("javascript:" + script);
+        }
     }
 
-    static void maybeCloseDialog(Activity stoppedActivity) {
+    @UiThread
+    static void maybeCloseDialog (Activity stoppedActivity) {
         if (dialog == null) {
             return;
         }
@@ -330,6 +347,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static Activity getDialogActivity(Context cont) {
         if (cont == null)
             return null;
@@ -341,11 +359,15 @@ class InAppMessagePresenter {
         return null;
     }
 
+    @UiThread
     private static void closeDialog(Activity dialogActivity) {
         if (dialog != null) {
-            unsetStatusBarColorForDialog(dialogActivity);
             dialog.setOnKeyListener(null);
             dialog.dismiss();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+                unsetStatusBarColorForDialog(dialogActivity);
+            }
+
         }
         dialog = null;
         wv = null;
@@ -384,140 +406,122 @@ class InAppMessagePresenter {
         window.setStatusBarColor(statusBarColor);
     }
 
-    @AnyThread
+    @UiThread
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     private static void unsetStatusBarColorForDialog(Activity dialogActivity) {
         if (dialogActivity == null) {
             return;
         }
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        Window window = dialogActivity.getWindow();
+        window.setStatusBarColor(prevStatusBarColor);
+
+        if (prevFlagTranslucentStatus) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+        }
+
+        if (!prevFlagDrawsSystemBarBackgrounds) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+        }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    @UiThread
+    private static void showWebView(@NonNull Activity currentActivity) {
+        if (dialog != null) {
             return;
         }
 
-        dialogActivity.runOnUiThread(new Runnable() {
-            @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-            @Override
-            public void run() {
-                Window window = dialogActivity.getWindow();
-                window.setStatusBarColor(prevStatusBarColor);
-
-                if (prevFlagTranslucentStatus) {
-                    window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-                }
-
-                if (!prevFlagDrawsSystemBarBackgrounds) {
-                    window.clearFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-                }
+        try {
+            if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                WebView.setWebContentsDebuggingEnabled(true);
             }
-        });
-    }
 
+            RelativeLayout.LayoutParams paramsWebView = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
+            dialog = new Dialog(currentActivity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
 
-    private static void showWebView(@NonNull Activity currentActivity) {
-        currentActivity.runOnUiThread(new Runnable() {
-            @SuppressLint("SetJavaScriptEnabled")
-            @Override
-            public void run() {
-                if (dialog != null) {
-                    return;
-                }
+            Window window = dialog.getWindow();
+            if (window != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                WindowManager.LayoutParams windowAttributes = dialog.getWindow().getAttributes();
+                windowAttributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
 
-                try {
-                    if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        WebView.setWebContentsDebuggingEnabled(true);
-                    }
-
-                    RelativeLayout.LayoutParams paramsWebView = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
-                    dialog = new Dialog(currentActivity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
-
-                    Window window = dialog.getWindow();
-                    if (window != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        WindowManager.LayoutParams windowAttributes = dialog.getWindow().getAttributes();
-                        windowAttributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
-
-                        View view = window.getDecorView();
-                        view.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-                    }
-
-                    LayoutInflater inflater = (LayoutInflater) currentActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-                    dialog.setContentView(inflater.inflate(R.layout.dialog_view, null), paramsWebView);
-                    dialog.setOnKeyListener(new Dialog.OnKeyListener() {
-                        @Override
-                        public boolean onKey(DialogInterface arg0, int keyCode, KeyEvent event) {
-                            if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() != KeyEvent.ACTION_DOWN) {
-                                InAppMessagePresenter.closeCurrentMessage(currentActivity);
-                            }
-                            return true;
-                        }
-                    });
-                    dialog.show();
-
-                    wv = dialog.findViewById(R.id.webview);
-                    spinner = dialog.findViewById(R.id.progressBar);
-
-                    int cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK;
-                    if (BuildConfig.DEBUG) {
-                        cacheMode = WebSettings.LOAD_NO_CACHE;
-                    }
-                    wv.getSettings().setCacheMode(cacheMode);
-
-                    wv.setBackgroundColor(android.graphics.Color.TRANSPARENT);
-
-                    WebSettings settings = wv.getSettings();
-                    settings.setJavaScriptEnabled(true);
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                        settings.setMediaPlaybackRequiresUserGesture(false);
-                    }
-
-                    wv.addJavascriptInterface(new InAppJavaScriptInterface(), InAppJavaScriptInterface.NAME);
-
-                    wv.setWebViewClient(new WebViewClient() {
-                        @Override
-                        public void onPageStarted(WebView view, String url, Bitmap favicon) {
-                            super.onPageStarted(view, url, favicon);
-                            InAppMessagePresenter.setSpinnerVisibility(View.VISIBLE);
-                        }
-
-                        @Override
-                        public void onPageFinished(WebView view, String url) {
-                            view.setBackgroundColor(android.graphics.Color.TRANSPARENT);
-                            setStatusBarColorForDialog(currentActivity);
-                            super.onPageFinished(view, url);
-                        }
-
-                        @SuppressWarnings("deprecation")
-                        @Override
-                        public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
-                            Kumulos.log(TAG, "Error code: " + errorCode + ". " + description + " " + failingUrl);
-
-                            String extension = failingUrl.substring(failingUrl.length() - 4);
-                            boolean isVideo = extension.matches(".mp4|.m4a|.m4p|.m4b|.m4r|.m4v");
-                            if (errorCode == -1 && "net::ERR_FAILED".equals(description) && isVideo) {
-                                // This is a workaround for a bug in the WebView.
-                                // See these chromium issues for more context:
-                                // https://bugs.chromium.org/p/chromium/issues/detail?id=1023678
-                                // https://bugs.chromium.org/p/chromium/issues/detail?id=1050635
-
-                                //We encountered the issue only with some (and not other) videos, but possibly not limited to other file types
-                                return;
-                            }
-
-                            closeDialog(currentActivity);
-                        }
-
-                        @TargetApi(android.os.Build.VERSION_CODES.M)
-                        @Override
-                        public void onReceivedError(WebView view, WebResourceRequest req, WebResourceError rerr) {
-                            onReceivedError(view, rerr.getErrorCode(), rerr.getDescription().toString(), req.getUrl().toString());
-                        }
-
-                    });
-
-                    wv.loadUrl(IN_APP_RENDERER_URL);
-                } catch (Exception e) {
-                    Kumulos.log(TAG, e.getMessage());
-                }
+                View view = window.getDecorView();
+                view.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
             }
-        });
+
+            LayoutInflater inflater = (LayoutInflater) currentActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            dialog.setContentView(inflater.inflate(R.layout.dialog_view, null), paramsWebView);
+            dialog.setOnKeyListener((arg0, keyCode, event) -> {
+                if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() != KeyEvent.ACTION_DOWN) {
+                    InAppMessagePresenter.closeCurrentMessage(currentActivity);
+                }
+                return true;
+            });
+            dialog.show();
+
+            wv = dialog.findViewById(R.id.webview);
+            spinner = dialog.findViewById(R.id.progressBar);
+
+            int cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK;
+            if (BuildConfig.DEBUG) {
+                cacheMode = WebSettings.LOAD_NO_CACHE;
+            }
+            wv.getSettings().setCacheMode(cacheMode);
+
+            wv.setBackgroundColor(android.graphics.Color.TRANSPARENT);
+
+            WebSettings settings = wv.getSettings();
+            settings.setJavaScriptEnabled(true);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                settings.setMediaPlaybackRequiresUserGesture(false);
+            }
+
+            wv.addJavascriptInterface(new InAppJavaScriptInterface(), InAppJavaScriptInterface.NAME);
+
+            wv.setWebViewClient(new WebViewClient() {
+                @Override
+                public void onPageStarted(WebView view, String url, Bitmap favicon) {
+                    super.onPageStarted(view, url, favicon);
+                    InAppMessagePresenter.setSpinnerVisibility(View.VISIBLE);
+                }
+
+                @Override
+                public void onPageFinished(WebView view, String url) {
+                    view.setBackgroundColor(android.graphics.Color.TRANSPARENT);
+                    setStatusBarColorForDialog(currentActivity);
+                    super.onPageFinished(view, url);
+                }
+                
+                @Override
+                public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+                    Kumulos.log(TAG, "Error code: " + errorCode + ". " + description + " " + failingUrl);
+
+                    String extension = failingUrl.substring(failingUrl.length() - 4);
+                    boolean isVideo = extension.matches(".mp4|.m4a|.m4p|.m4b|.m4r|.m4v");
+                    if (errorCode == -1 && "net::ERR_FAILED".equals(description) && isVideo) {
+                        // This is a workaround for a bug in the WebView.
+                        // See these chromium issues for more context:
+                        // https://bugs.chromium.org/p/chromium/issues/detail?id=1023678
+                        // https://bugs.chromium.org/p/chromium/issues/detail?id=1050635
+
+                        //We encountered the issue only with some (and not other) videos, but possibly not limited to other file types
+                        return;
+                    }
+
+                    closeDialog(currentActivity);
+                }
+
+                @TargetApi(android.os.Build.VERSION_CODES.M)
+                @Override
+                public void onReceivedError(WebView view, WebResourceRequest req, WebResourceError rerr) {
+                    onReceivedError(view, rerr.getErrorCode(), rerr.getDescription().toString(), req.getUrl().toString());
+                }
+
+            });
+
+            wv.loadUrl(IN_APP_RENDERER_URL);
+        } catch (Exception e) {
+            Kumulos.log(TAG, e.getMessage());
+        }
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/KumulosConfig.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosConfig.java
@@ -20,7 +20,7 @@ public final class KumulosConfig {
 
     @DrawableRes
     static final int DEFAULT_NOTIFICATION_ICON_ID = R.drawable.kumulos_ic_stat_notifications;
-    static final int DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS = 40;
+    static final int DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS = 23;
     private static final String KEY_API_KEY = "apiKey";
     private static final String KEY_SECRET_KEY = "secretKey";
     private static final String KEY_NOTIFICATION_SMALL_ICON_ID = "smallNotificationIconId";

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -41,7 +41,7 @@ public class KumulosInApp {
      *
      * @param context
      */
-    public static List<InAppInboxItem> getInboxItems(Context context) {
+    public static List<InAppInboxItem> getInboxItems(@NonNull Context context) {
         boolean inAppEnabled = isInAppEnabled();
         if (!inAppEnabled) {
             throw new RuntimeException("Kumulos: It is only possible to read In App inbox if In App messaging is enabled");
@@ -56,7 +56,7 @@ public class KumulosInApp {
      * @param context
      * @param item inbox item to present
      */
-    public static InboxMessagePresentationResult presentInboxMessage(Context context, @NonNull InAppInboxItem item) {
+    public static InboxMessagePresentationResult presentInboxMessage(@NonNull Context context, @NonNull InAppInboxItem item) {
         boolean inAppEnabled = isInAppEnabled();
         if (!inAppEnabled) {
             throw new RuntimeException("Kumulos: It is only possible to present In App inbox if In App messaging is enabled");
@@ -71,7 +71,7 @@ public class KumulosInApp {
      * @param context
      * @param item inbox item to delete
      */
-    public static boolean deleteMessageFromInbox(Context context, @NonNull InAppInboxItem item) {
+    public static boolean deleteMessageFromInbox(@NonNull Context context, @NonNull InAppInboxItem item) {
         return InAppMessageService.deleteMessageFromInbox(context, item.getId());
     }
 
@@ -81,7 +81,7 @@ public class KumulosInApp {
      * @param context
      * @param item inbox item to mark as read
      */
-    public static boolean markAsRead(Context context, @NonNull InAppInboxItem item) {
+    public static boolean markAsRead(@NonNull Context context, @NonNull InAppInboxItem item) {
         if (item.isRead()) {
             return false;
         }
@@ -97,7 +97,7 @@ public class KumulosInApp {
      *
      * @param context
      */
-    public static boolean markAllInboxItemsAsRead(Context context) {
+    public static boolean markAllInboxItemsAsRead(@NonNull Context context) {
         return InAppMessageService.markAllInboxItemsAsRead(context);
     }
 
@@ -118,7 +118,7 @@ public class KumulosInApp {
      * @param context
      * @param inboxSummaryHandler handler
      */
-    public static void getInboxSummaryAsync(Context context, @NonNull InAppInboxSummaryHandler inboxSummaryHandler) {
+    public static void getInboxSummaryAsync(@NonNull Context context, @NonNull InAppInboxSummaryHandler inboxSummaryHandler) {
         Runnable task = new InAppContract.ReadInboxSummaryRunnable(context, inboxSummaryHandler);
         Kumulos.executorService.submit(task);
     }

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -5,6 +5,7 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.json.JSONException;
@@ -55,7 +56,7 @@ public class KumulosInApp {
      * @param context
      * @param item inbox item to present
      */
-    public static InboxMessagePresentationResult presentInboxMessage(Context context, InAppInboxItem item) {
+    public static InboxMessagePresentationResult presentInboxMessage(Context context, @NonNull InAppInboxItem item) {
         boolean inAppEnabled = isInAppEnabled();
         if (!inAppEnabled) {
             throw new RuntimeException("Kumulos: It is only possible to present In App inbox if In App messaging is enabled");
@@ -70,7 +71,7 @@ public class KumulosInApp {
      * @param context
      * @param item inbox item to delete
      */
-    public static boolean deleteMessageFromInbox(Context context, InAppInboxItem item) {
+    public static boolean deleteMessageFromInbox(Context context, @NonNull InAppInboxItem item) {
         return InAppMessageService.deleteMessageFromInbox(context, item.getId());
     }
 
@@ -80,7 +81,7 @@ public class KumulosInApp {
      * @param context
      * @param item inbox item to mark as read
      */
-    public static boolean markAsRead(Context context, InAppInboxItem item) {
+    public static boolean markAsRead(Context context, @NonNull InAppInboxItem item) {
         if (item.isRead()) {
             return false;
         }
@@ -117,7 +118,7 @@ public class KumulosInApp {
      * @param context
      * @param inboxSummaryHandler handler
      */
-    public static void getInboxSummaryAsync(Context context, InAppInboxSummaryHandler inboxSummaryHandler) {
+    public static void getInboxSummaryAsync(Context context, @NonNull InAppInboxSummaryHandler inboxSummaryHandler) {
         Runnable task = new InAppContract.ReadInboxSummaryRunnable(context, inboxSummaryHandler);
         Kumulos.executorService.submit(task);
     }

--- a/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
+++ b/kumulos/src/main/java/com/kumulos/android/KumulosInApp.java
@@ -26,10 +26,10 @@ public class KumulosInApp {
         void run();
     }
 
-    static InAppInboxUpdatedHandler inboxUpdatedHandler;
+    private static InAppInboxUpdatedHandler inboxUpdatedHandler;
 
     public interface InAppInboxSummaryHandler {
-        void run(InAppInboxSummary summary);
+        void run(@Nullable InAppInboxSummary summary);
     }
 
     //==============================================================================================
@@ -117,7 +117,7 @@ public class KumulosInApp {
      * @param context
      * @param inboxSummaryHandler handler
      */
-    public static void getInboxSummaryAsync(Context context, @Nullable InAppInboxSummaryHandler inboxSummaryHandler) {
+    public static void getInboxSummaryAsync(Context context, InAppInboxSummaryHandler inboxSummaryHandler) {
         Runnable task = new InAppContract.ReadInboxSummaryRunnable(context, inboxSummaryHandler);
         Kumulos.executorService.submit(task);
     }

--- a/kumulos/src/main/java/com/kumulos/android/MediaHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/MediaHelper.java
@@ -1,0 +1,19 @@
+package com.kumulos.android;
+
+import androidx.annotation.NonNull;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class MediaHelper {
+
+    private static final String MEDIA_RESIZER_BASE_URL = "https://i.app.delivery";
+
+    static @NonNull URL getCompletePictureUrl(String pictureUrl, int width) throws MalformedURLException{
+        if (pictureUrl.substring(0, 8).equals("https://") || pictureUrl.substring(0, 7).equals("http://")){
+            return new URL(pictureUrl);
+        }
+
+        return new URL(MEDIA_RESIZER_BASE_URL + "/" + width + "x/" + pictureUrl);
+    }
+}

--- a/kumulos/src/main/java/com/kumulos/android/MediaHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/MediaHelper.java
@@ -9,7 +9,7 @@ public class MediaHelper {
 
     private static final String MEDIA_RESIZER_BASE_URL = "https://i.app.delivery";
 
-    static @NonNull URL getCompletePictureUrl(String pictureUrl, int width) throws MalformedURLException{
+    static @NonNull URL getCompletePictureUrl(@NonNull String pictureUrl, int width) throws MalformedURLException{
         if (pictureUrl.substring(0, 8).equals("https://") || pictureUrl.substring(0, 7).equals("http://")){
             return new URL(pictureUrl);
         }

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -48,7 +48,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
     private static final String DEFAULT_CHANNEL_ID = "kumulos_general_v3";
     protected static final String KUMULOS_NOTIFICATION_TAG = "kumulos";
 
-    private static final String MEDIA_RESIZER_BASE_URL = "https://i.app.delivery";
+
 
     @Override
     final public void onReceive(Context context, Intent intent) {
@@ -490,13 +490,8 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 throw new RuntimeException("Kumulos: pictureUrl cannot be null at this point");
             }
 
-            if (pictureUrl.substring(0, 8).equals("https://") || pictureUrl.substring(0, 7).equals("http://")){
-                return new URL(pictureUrl);
-            }
-
             DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
-
-            return new URL(MEDIA_RESIZER_BASE_URL + "/" + metrics.widthPixels + "x/" + pictureUrl);
+            return MediaHelper.getCompletePictureUrl(pictureUrl,  metrics.widthPixels);
         }
 
         @Override

--- a/kumulos/src/main/java/com/kumulos/android/PushRegistration.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushRegistration.java
@@ -61,7 +61,7 @@ final class PushRegistration {
                 case LATEST:
                     this.registerFcmNew(context);
                     break;
-                case DEPRECATED:
+                case DEPRECATED_1:
                     this.registerFcmOld(context);
                     break;
                 case UNKNOWN:
@@ -87,7 +87,6 @@ final class PushRegistration {
 
                     String token = task.getResult();
 
-                    Log.d("vlad", "victory new: " + token);
                     Kumulos.pushTokenStore(context, PushTokenType.FCM, token);
                 });
             } catch (NoSuchMethodException e) {
@@ -124,7 +123,7 @@ final class PushRegistration {
                     try {
                         Method getTokenMethod = instanceIdResult.getClass().getMethod("getToken");
                         String token = (String) getTokenMethod.invoke(instanceIdResult);
-                        Log.d("vlad", "victory old: " + token);
+
                         Kumulos.pushTokenStore(context, PushTokenType.FCM, token);
                     } catch (Exception e) {
                         Log.e(TAG, "Failed to get FCM token with FirebaseMessaging <21.0.0, in callback : " + e.getMessage());
@@ -211,7 +210,7 @@ final class PushRegistration {
                 case LATEST:
                     this.unregisterFcmNew(context);
                     break;
-                case DEPRECATED:
+                case DEPRECATED_1:
                     this.unregisterFcmOld(context);
                     break;
                 case UNKNOWN:
@@ -226,7 +225,7 @@ final class PushRegistration {
 
             Exception exception = null;
             try {
-                Method deleteToken = instance.getClass().getMethod("deleteToken");//TODO: same?
+                Method deleteToken = instance.getClass().getMethod("deleteToken");
                 Task<Void> result = (Task<Void>) deleteToken.invoke(instance);
 
                 result.addOnCompleteListener(Kumulos.executorService, task -> {
@@ -312,7 +311,4 @@ final class PushRegistration {
     String getHmsAppId(Context context) {
         return AGConnectServicesConfig.fromContext(context).getString("client/app_id");
     }
-
 }
-
-

--- a/kumulos/src/main/java/com/kumulos/android/PushRegistration.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushRegistration.java
@@ -4,17 +4,26 @@ import android.content.Context;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
+//import com.google.firebase.iid.FirebaseInstanceId;
+//import static com.google.firebase.iid.InstanceIdResult;
+
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.huawei.agconnect.config.AGConnectServicesConfig;
 import com.huawei.hms.aaid.HmsInstanceId;
 import com.huawei.hms.common.ApiException;
 
 import java.io.IOException;
+import java.lang.invoke.LambdaConversionException;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.Executor;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 final class PushRegistration {
@@ -56,11 +65,119 @@ final class PushRegistration {
         }
 
         private void registerFcm(Context context) {
-            Task<InstanceIdResult> result = FirebaseInstanceId.getInstance().getInstanceId();
+            if (this.hasLatestFirebaseMessaging()) {
+                //FirebaseMessaging [21.0.0, 22.99.99]
+                this.registerFcmNew(context);
+                return;
+            }
 
-            result.addOnSuccessListener(Kumulos.executorService, instanceIdResult ->
-                    Kumulos.pushTokenStore(context, PushTokenType.FCM, instanceIdResult.getToken()));
+            if (this.hasDeprecatedFirebaseMessaging()) {
+                //FirebaseMessaging [19.0.0 - 22.0.0)
+                this.registerFcmOld(context);
+                return;
+            }
+
+            Log.e(TAG, "FirebaseMessaging version not supported");
         }
+
+
+        @SuppressWarnings("unchecked")
+        private void registerFcmNew(Context context) {
+            FirebaseMessaging instance = FirebaseMessaging.getInstance();
+
+            Exception exception = null;
+            try {
+                Method getToken = instance.getClass().getMethod("getToken");
+                Task<String> result = (Task<String>) getToken.invoke(instance);
+
+                result.addOnCompleteListener(Kumulos.executorService, task -> {
+                    if (!task.isSuccessful()) {
+                        Log.w(TAG, "Fetching FCM registration token failed for FirebaseMessaging >=21.0.0 ", task.getException());
+                        return;
+                    }
+
+                    String token = task.getResult();
+
+                    Log.d("vlad", "victory new: " + token);
+                    Kumulos.pushTokenStore(context, PushTokenType.FCM, token);
+                });
+            } catch (NoSuchMethodException e) {
+                exception = e;
+            } catch (IllegalAccessException e) {
+                exception = e;
+            } catch (InvocationTargetException e) {
+                exception = e;
+            }
+
+            if (exception != null) {
+                Log.e(TAG, "Failed to get FCM token with FirebaseMessaging >=21.0.0 : " + exception.getMessage());
+            }
+        }
+
+
+        private void registerFcmOld(Context context) {
+            // Equivalent of:
+            // Task<InstanceIdResult> result = com.google.firebase.iid.FirebaseInstanceId.getInstance().getInstanceId();
+            // result.addOnSuccessListener(Kumulos.executorService, instanceIdResult ->
+            //        Kumulos.pushTokenStore(context, PushTokenType.FCM, instanceIdResult.getToken()));
+
+            Exception exception = null;
+            try {
+                Class<?> FirebaseInstanceIdClass = Class.forName("com.google.firebase.iid.FirebaseInstanceId");
+
+                Method getInstanceMethod = FirebaseInstanceIdClass.getMethod("getInstance");
+                Object instance = getInstanceMethod.invoke(null);
+
+                Method getInstanceIdMethod = instance.getClass().getMethod("getInstanceId");
+                Object task = getInstanceIdMethod.invoke(instance);
+
+                OnSuccessListener<?> callback = instanceIdResult -> {
+                    try {
+                        Method getTokenMethod = instanceIdResult.getClass().getMethod("getToken");
+                        String token = (String) getTokenMethod.invoke(instanceIdResult);
+                        Log.d("vlad", "victory old: " + token);
+                        Kumulos.pushTokenStore(context, PushTokenType.FCM, token);
+                    } catch (Exception e) {
+                        Log.e(TAG, "Failed to get FCM token with FirebaseMessaging <21.0.0, in callback : " + e.getMessage());
+                    }
+                };
+
+                Method addOnSuccessListenerMethod = task.getClass().getMethod("addOnSuccessListener", Executor.class, OnSuccessListener.class);
+                addOnSuccessListenerMethod.invoke(task, Kumulos.executorService, callback);
+            } catch (ClassNotFoundException e) {
+                exception = e;
+            } catch (NoSuchMethodException e) {
+                exception = e;
+            } catch (IllegalAccessException e) {
+                exception = e;
+            } catch (InvocationTargetException e) {
+                exception = e;
+            }
+
+            if (exception != null) {
+                Log.e(TAG, "Failed to get FCM token with FirebaseMessaging <21.0.0 : " + exception.getMessage());
+            }
+        }
+
+        private boolean hasDeprecatedFirebaseMessaging() {
+            try {
+                Class.forName("com.google.firebase.iid.FirebaseInstanceId");
+                return true;
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
+        }
+
+        private boolean hasLatestFirebaseMessaging() {
+            FirebaseMessaging instance = FirebaseMessaging.getInstance();
+            try {
+                instance.getClass().getMethod("getToken");
+                return true;
+            } catch (NoSuchMethodException e) {
+                return false;
+            }
+        }
+
 
         private void registerHms(Context context) {
             try {
@@ -105,7 +222,7 @@ final class PushRegistration {
 
             switch (api) {
                 case FCM:
-                    this.unregisterFcm(context);
+                    //this.unregisterFcm(context);
                     break;
                 case HMS:
                     this.unregisterHms(context);
@@ -116,19 +233,19 @@ final class PushRegistration {
             }
         }
 
-        private void unregisterFcm(Context context) {
-            Task<InstanceIdResult> result = FirebaseInstanceId.getInstance().getInstanceId();
-
-            result.addOnSuccessListener(Kumulos.executorService, instanceIdResult -> {
-                try {
-                    FirebaseInstanceId.getInstance().deleteToken(instanceIdResult.getToken(),
-                            FirebaseMessaging.INSTANCE_ID_SCOPE);
-                    Kumulos.trackEventImmediately(context, AnalyticsContract.EVENT_TYPE_PUSH_DEVICE_UNSUBSCRIBED, null);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            });
-        }
+//        private void unregisterFcm(Context context) {
+//            Task<InstanceIdResult> result = FirebaseInstanceId.getInstance().getInstanceId();
+//
+//            result.addOnSuccessListener(Kumulos.executorService, instanceIdResult -> {
+//                try {
+//                    FirebaseInstanceId.getInstance().deleteToken(instanceIdResult.getToken(),
+//                            FirebaseMessaging.INSTANCE_ID_SCOPE);
+//                    Kumulos.trackEventImmediately(context, AnalyticsContract.EVENT_TYPE_PUSH_DEVICE_UNSUBSCRIBED, null);
+//                } catch (IOException e) {
+//                    e.printStackTrace();
+//                }
+//            });
+//        }
 
         private void unregisterHms(Context context) {
             try {
@@ -147,8 +264,11 @@ final class PushRegistration {
         }
     }
 
-    private static @Nullable String getHmsAppId(Context context) {
+    private static @Nullable
+    String getHmsAppId(Context context) {
         return AGConnectServicesConfig.fromContext(context).getString("client/app_id");
     }
 
 }
+
+


### PR DESCRIPTION
### Description of Changes

1) Drop session timeout to 23 seconds to match ios
2) Minor tweaks to annotations missed in inbox enhancements PR
3) Similarly to ObjC expose imageUrl on inbox items. For this add 2 methods: `public @Nullable URL getImageUrl(int width)` and `public @Nullable URL getImageUrl()`. Default width 300px
4) update targetSdk and compileSdk versions to 30. No [changes](https://developer.android.com/about/versions/11/behavior-changes-11) affect us.
5) version range for FirebaseMessaging [19.0.0, 22.99.99]. 19.0.0 is the 1st version supporting androidx. 22.0.0 is currently latest version of FM. Token retrieval/deletion API changed along the way, so, support 2 API versions. 

Range [19.0.0, 22.99.99] means that:
- If there is only 1 dependency on FM, latest version from the range is selected. 
- If there is a specific version in the range, it is selected
- If there is a specific version exceeding the range, outcome depends on the build tool: with [gradle](https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:resolution-strategy) specific version is selected, with [maven](https://maven.apache.org/pom.html#dependency-version-requirement-specification) build fails. 

6) Thread safety of InAppMessagePresenter (#61)

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
