### PR TITLE
Bugfixes for InAppMessagePresenter

### DIFF
--- a/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.work.Constraints;
@@ -422,6 +423,7 @@ import androidx.work.WorkManager;
         public void onActivitySaveInstanceState(Activity activity, Bundle outState) {  /* noop */ }
 
         @Override
+        @MainThread
         public void onActivityDestroyed(Activity activity) {
             InAppMessagePresenter.maybeCloseDialog(activity);
 

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -178,6 +178,10 @@ class InAppMessagePresenter {
         wv.post(new Runnable() {
             @Override
             public void run() {
+                if (wv == null) {
+                    return;
+                }
+
                 maybeSetNotchInsets(context);
                 presentMessageToClient();
             }
@@ -259,6 +263,10 @@ class InAppMessagePresenter {
         wv.post(new Runnable() {
             @Override
             public void run() {
+                if (wv == null) {
+                    return;
+                }
+
                 if (!messageQueue.isEmpty()){
                     messageQueue.remove(0);
                 }
@@ -287,7 +295,7 @@ class InAppMessagePresenter {
         wv.post(new Runnable() {
             @Override
             public void run() {
-                if (spinner != null) {
+                if (wv != null && spinner != null) {
                     spinner.setVisibility(visibility);
                 }
             }
@@ -301,6 +309,10 @@ class InAppMessagePresenter {
         wv.post(new Runnable() {
             @Override
             public void run() {
+                if (wv == null) {
+                    return;
+                }
+
                 JSONObject j = new JSONObject();
                 try {
                     j.put("data", data);

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -6,7 +6,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.ContextWrapper;
-import android.content.DialogInterface;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.os.Build;
@@ -35,11 +34,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import androidx.annotation.AnyThread;
-import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.UiThread;
-import androidx.annotation.WorkerThread;
 
 class InAppMessagePresenter {
 
@@ -222,7 +219,7 @@ class InAppMessagePresenter {
             return;
         }
 
-        Pair notchPositions = determineNotchPositions(window, cutoutBoundingRectangles);
+        Pair<Boolean, Boolean> notchPositions = determineNotchPositions(window, cutoutBoundingRectangles);
         float density = context.getResources().getDisplayMetrics().density;
 
         JSONObject notchData = new JSONObject();
@@ -262,7 +259,7 @@ class InAppMessagePresenter {
             }
         }
 
-        return new Pair<Boolean, Boolean>(hasNotchOnTheLeft, hasNotchOnTheRight);
+        return new Pair<>(hasNotchOnTheLeft, hasNotchOnTheRight);
     }
 
     @AnyThread
@@ -454,14 +451,11 @@ class InAppMessagePresenter {
 
             LayoutInflater inflater = (LayoutInflater) currentActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             dialog.setContentView(inflater.inflate(R.layout.dialog_view, null), paramsWebView);
-            dialog.setOnKeyListener(new Dialog.OnKeyListener() {
-                @Override
-                public boolean onKey(DialogInterface arg0, int keyCode, KeyEvent event) {
-                    if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() != KeyEvent.ACTION_DOWN) {
-                        InAppMessagePresenter.closeCurrentMessage(currentActivity);
-                    }
-                    return true;
+            dialog.setOnKeyListener((arg0, keyCode, event) -> {
+                if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() != KeyEvent.ACTION_DOWN) {
+                    InAppMessagePresenter.closeCurrentMessage(currentActivity);
                 }
+                return true;
             });
             dialog.show();
 
@@ -497,8 +491,7 @@ class InAppMessagePresenter {
                     setStatusBarColorForDialog(currentActivity);
                     super.onPageFinished(view, url);
                 }
-
-                @SuppressWarnings("deprecation")
+                
                 @Override
                 public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
                     Kumulos.log(TAG, "Error code: " + errorCode + ". " + description + " " + failingUrl);

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -35,9 +35,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import androidx.annotation.AnyThread;
+import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.UiThread;
+import androidx.annotation.WorkerThread;
 
 class InAppMessagePresenter {
 
@@ -63,6 +65,15 @@ class InAppMessagePresenter {
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
 
         if (currentActivity == null) {
+            return;
+        }
+
+        currentActivity.runOnUiThread(() -> presentMessagesOnUiThread(currentActivity, itemsToPresent, tickleIds));
+    }
+
+    @UiThread
+    private static void presentMessagesOnUiThread(Activity currentActivity, List<InAppMessage> itemsToPresent, List<Integer> tickleIds){
+        if (currentActivity == null){
             return;
         }
 
@@ -98,6 +109,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static void maybeRefreshFirstMessageInQueue(List<InAppMessage> oldQueue) {
         if (oldQueue.isEmpty()) {
             return;
@@ -110,6 +122,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static void moveTicklesToFront(List<Integer> tickleIds) {
         if (tickleIds == null || tickleIds.isEmpty()) {
             return;
@@ -128,6 +141,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static void addMessagesToQueue(List<InAppMessage> itemsToPresent) {
         for (InAppMessage messageToAppend : itemsToPresent) {
             boolean exists = false;
@@ -144,6 +158,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static void presentMessageToClient() {
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
         if (currentActivity == null) {
@@ -170,24 +185,23 @@ class InAppMessagePresenter {
         sendToClient(HOST_MESSAGE_TYPE_PRESENT_MESSAGE, message.getContent());
     }
 
+    @AnyThread
     static void clientReady(Context context) {
         if (wv == null) {
             return;
         }
 
-        wv.post(new Runnable() {
-            @Override
-            public void run() {
-                if (wv == null) {
-                    return;
-                }
-
-                maybeSetNotchInsets(context);
-                presentMessageToClient();
+        wv.post(() -> {
+            if (wv == null) {
+                return;
             }
+
+            maybeSetNotchInsets(context);
+            presentMessageToClient();
         });
     }
 
+    @UiThread
     private static void maybeSetNotchInsets(Context context) {
         if (dialog == null) {
             return;
@@ -226,6 +240,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static Pair<Boolean, Boolean> determineNotchPositions(Window window, List<Rect> cutoutBoundingRectangles) {
         Display display = window.getWindowManager().getDefaultDisplay();
         DisplayMetrics outMetrics = new DisplayMetrics();
@@ -250,90 +265,82 @@ class InAppMessagePresenter {
         return new Pair<Boolean, Boolean>(hasNotchOnTheLeft, hasNotchOnTheRight);
     }
 
+    @AnyThread
     static void messageOpened(Context context) {
         InAppMessageService.handleMessageOpened(context, messageQueue.get(0));
         setSpinnerVisibility(View.GONE);
     }
 
+    @AnyThread
     static void messageClosed() {
         if (wv == null) {
             return;
         }
 
-        wv.post(new Runnable() {
-            @Override
-            public void run() {
-                if (wv == null) {
-                    return;
-                }
-
-                if (!messageQueue.isEmpty()){
-                    messageQueue.remove(0);
-                }
-
-                presentMessageToClient();
+        wv.post(() -> {
+            if (wv == null) {
+                return;
             }
+
+            if (!messageQueue.isEmpty()){
+                messageQueue.remove(0);
+            }
+
+            presentMessageToClient();
         });
     }
 
-    static void closeCurrentMessage(Context context) {
-        if (dialog == null || messageQueue.isEmpty()) {
+    @AnyThread
+    static void closeCurrentMessage(Activity activity) {
+        if (dialog == null || messageQueue.isEmpty() || activity == null) {
             return;
         }
 
         InAppMessage message = messageQueue.get(0);
 
-        InAppMessagePresenter.sendToClient(HOST_MESSAGE_TYPE_CLOSE_MESSAGE, null);
+        activity.runOnUiThread(() -> InAppMessagePresenter.sendToClient(HOST_MESSAGE_TYPE_CLOSE_MESSAGE, null));
 
-        InAppMessageService.handleMessageClosed(context, message);
+        InAppMessageService.handleMessageClosed(activity, message);
     }
 
+    @AnyThread
     private static void setSpinnerVisibility(int visibility) {
         if (wv == null) {
             return;
         }
-        wv.post(new Runnable() {
-            @Override
-            public void run() {
-                if (wv != null && spinner != null) {
-                    spinner.setVisibility(visibility);
-                }
+        wv.post(() -> {
+            if (wv != null && spinner != null) {
+                spinner.setVisibility(visibility);
             }
         });
     }
 
+    @UiThread
     private static void sendToClient(String type, JSONObject data) {
         if (wv == null) {
             return;
         }
-        wv.post(new Runnable() {
-            @Override
-            public void run() {
-                if (wv == null) {
-                    return;
-                }
 
-                JSONObject j = new JSONObject();
-                try {
-                    j.put("data", data);
-                    j.put("type", type);
-                } catch (JSONException e) {
-                    Log.d(TAG, "Could not create client message");
-                    return;
-                }
+        JSONObject j = new JSONObject();
+        try {
+            j.put("data", data);
+            j.put("type", type);
+        } catch (JSONException e) {
+            Log.d(TAG, "Could not create client message");
+            return;
+        }
 
-                String script = "window.postHostMessage(" + j.toString() + ")";
+        String script = "window.postHostMessage(" + j.toString() + ")";
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    wv.evaluateJavascript(script, null);
-                } else {
-                    wv.loadUrl("javascript:" + script);
-                }
-            }
-        });
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            wv.evaluateJavascript(script, null);
+        } else {
+            wv.loadUrl("javascript:" + script);
+        }
     }
 
-    static void maybeCloseDialog(Activity stoppedActivity) {
+    @UiThread
+    static void maybeCloseDialog (Activity stoppedActivity) {
         if (dialog == null) {
             return;
         }
@@ -343,6 +350,7 @@ class InAppMessagePresenter {
         }
     }
 
+    @UiThread
     private static Activity getDialogActivity(Context cont) {
         if (cont == null)
             return null;
@@ -354,11 +362,15 @@ class InAppMessagePresenter {
         return null;
     }
 
+    @UiThread
     private static void closeDialog(Activity dialogActivity) {
         if (dialog != null) {
             dialog.setOnKeyListener(null);
             dialog.dismiss();
-            unsetStatusBarColorForDialog(dialogActivity);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+                unsetStatusBarColorForDialog(dialogActivity);
+            }
+
         }
         dialog = null;
         wv = null;
@@ -397,140 +409,126 @@ class InAppMessagePresenter {
         window.setStatusBarColor(statusBarColor);
     }
 
-    @AnyThread
+    @UiThread
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     private static void unsetStatusBarColorForDialog(Activity dialogActivity) {
         if (dialogActivity == null) {
             return;
         }
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        Window window = dialogActivity.getWindow();
+        window.setStatusBarColor(prevStatusBarColor);
+
+        if (prevFlagTranslucentStatus) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+        }
+
+        if (!prevFlagDrawsSystemBarBackgrounds) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+        }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    @UiThread
+    private static void showWebView(@NonNull Activity currentActivity) {
+        if (dialog != null) {
             return;
         }
 
-        dialogActivity.runOnUiThread(new Runnable() {
-            @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-            @Override
-            public void run() {
-                Window window = dialogActivity.getWindow();
-                window.setStatusBarColor(prevStatusBarColor);
-
-                if (prevFlagTranslucentStatus) {
-                    window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-                }
-
-                if (!prevFlagDrawsSystemBarBackgrounds) {
-                    window.clearFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-                }
+        try {
+            if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                WebView.setWebContentsDebuggingEnabled(true);
             }
-        });
-    }
 
+            RelativeLayout.LayoutParams paramsWebView = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
+            dialog = new Dialog(currentActivity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
 
-    private static void showWebView(@NonNull Activity currentActivity) {
-        currentActivity.runOnUiThread(new Runnable() {
-            @SuppressLint("SetJavaScriptEnabled")
-            @Override
-            public void run() {
-                if (dialog != null) {
-                    return;
-                }
+            Window window = dialog.getWindow();
+            if (window != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                WindowManager.LayoutParams windowAttributes = dialog.getWindow().getAttributes();
+                windowAttributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
 
-                try {
-                    if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        WebView.setWebContentsDebuggingEnabled(true);
-                    }
-
-                    RelativeLayout.LayoutParams paramsWebView = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
-                    dialog = new Dialog(currentActivity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
-
-                    Window window = dialog.getWindow();
-                    if (window != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        WindowManager.LayoutParams windowAttributes = dialog.getWindow().getAttributes();
-                        windowAttributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
-
-                        View view = window.getDecorView();
-                        view.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-                    }
-
-                    LayoutInflater inflater = (LayoutInflater) currentActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-                    dialog.setContentView(inflater.inflate(R.layout.dialog_view, null), paramsWebView);
-                    dialog.setOnKeyListener(new Dialog.OnKeyListener() {
-                        @Override
-                        public boolean onKey(DialogInterface arg0, int keyCode, KeyEvent event) {
-                            if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() != KeyEvent.ACTION_DOWN) {
-                                InAppMessagePresenter.closeCurrentMessage(currentActivity);
-                            }
-                            return true;
-                        }
-                    });
-                    dialog.show();
-
-                    wv = dialog.findViewById(R.id.webview);
-                    spinner = dialog.findViewById(R.id.progressBar);
-
-                    int cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK;
-                    if (BuildConfig.DEBUG) {
-                        cacheMode = WebSettings.LOAD_NO_CACHE;
-                    }
-                    wv.getSettings().setCacheMode(cacheMode);
-
-                    wv.setBackgroundColor(android.graphics.Color.TRANSPARENT);
-
-                    WebSettings settings = wv.getSettings();
-                    settings.setJavaScriptEnabled(true);
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                        settings.setMediaPlaybackRequiresUserGesture(false);
-                    }
-
-                    wv.addJavascriptInterface(new InAppJavaScriptInterface(), InAppJavaScriptInterface.NAME);
-
-                    wv.setWebViewClient(new WebViewClient() {
-                        @Override
-                        public void onPageStarted(WebView view, String url, Bitmap favicon) {
-                            super.onPageStarted(view, url, favicon);
-                            InAppMessagePresenter.setSpinnerVisibility(View.VISIBLE);
-                        }
-
-                        @Override
-                        public void onPageFinished(WebView view, String url) {
-                            view.setBackgroundColor(android.graphics.Color.TRANSPARENT);
-                            setStatusBarColorForDialog(currentActivity);
-                            super.onPageFinished(view, url);
-                        }
-
-                        @SuppressWarnings("deprecation")
-                        @Override
-                        public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
-                            Kumulos.log(TAG, "Error code: " + errorCode + ". " + description + " " + failingUrl);
-
-                            String extension = failingUrl.substring(failingUrl.length() - 4);
-                            boolean isVideo = extension.matches(".mp4|.m4a|.m4p|.m4b|.m4r|.m4v");
-                            if (errorCode == -1 && "net::ERR_FAILED".equals(description) && isVideo) {
-                                // This is a workaround for a bug in the WebView.
-                                // See these chromium issues for more context:
-                                // https://bugs.chromium.org/p/chromium/issues/detail?id=1023678
-                                // https://bugs.chromium.org/p/chromium/issues/detail?id=1050635
-
-                                //We encountered the issue only with some (and not other) videos, but possibly not limited to other file types
-                                return;
-                            }
-
-                            closeDialog(currentActivity);
-                        }
-
-                        @TargetApi(android.os.Build.VERSION_CODES.M)
-                        @Override
-                        public void onReceivedError(WebView view, WebResourceRequest req, WebResourceError rerr) {
-                            onReceivedError(view, rerr.getErrorCode(), rerr.getDescription().toString(), req.getUrl().toString());
-                        }
-
-                    });
-
-                    wv.loadUrl(IN_APP_RENDERER_URL);
-                } catch (Exception e) {
-                    Kumulos.log(TAG, e.getMessage());
-                }
+                View view = window.getDecorView();
+                view.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
             }
-        });
+
+            LayoutInflater inflater = (LayoutInflater) currentActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            dialog.setContentView(inflater.inflate(R.layout.dialog_view, null), paramsWebView);
+            dialog.setOnKeyListener(new Dialog.OnKeyListener() {
+                @Override
+                public boolean onKey(DialogInterface arg0, int keyCode, KeyEvent event) {
+                    if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() != KeyEvent.ACTION_DOWN) {
+                        InAppMessagePresenter.closeCurrentMessage(currentActivity);
+                    }
+                    return true;
+                }
+            });
+            dialog.show();
+
+            wv = dialog.findViewById(R.id.webview);
+            spinner = dialog.findViewById(R.id.progressBar);
+
+            int cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK;
+            if (BuildConfig.DEBUG) {
+                cacheMode = WebSettings.LOAD_NO_CACHE;
+            }
+            wv.getSettings().setCacheMode(cacheMode);
+
+            wv.setBackgroundColor(android.graphics.Color.TRANSPARENT);
+
+            WebSettings settings = wv.getSettings();
+            settings.setJavaScriptEnabled(true);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                settings.setMediaPlaybackRequiresUserGesture(false);
+            }
+
+            wv.addJavascriptInterface(new InAppJavaScriptInterface(), InAppJavaScriptInterface.NAME);
+
+            wv.setWebViewClient(new WebViewClient() {
+                @Override
+                public void onPageStarted(WebView view, String url, Bitmap favicon) {
+                    super.onPageStarted(view, url, favicon);
+                    InAppMessagePresenter.setSpinnerVisibility(View.VISIBLE);
+                }
+
+                @Override
+                public void onPageFinished(WebView view, String url) {
+                    view.setBackgroundColor(android.graphics.Color.TRANSPARENT);
+                    setStatusBarColorForDialog(currentActivity);
+                    super.onPageFinished(view, url);
+                }
+
+                @SuppressWarnings("deprecation")
+                @Override
+                public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+                    Kumulos.log(TAG, "Error code: " + errorCode + ". " + description + " " + failingUrl);
+
+                    String extension = failingUrl.substring(failingUrl.length() - 4);
+                    boolean isVideo = extension.matches(".mp4|.m4a|.m4p|.m4b|.m4r|.m4v");
+                    if (errorCode == -1 && "net::ERR_FAILED".equals(description) && isVideo) {
+                        // This is a workaround for a bug in the WebView.
+                        // See these chromium issues for more context:
+                        // https://bugs.chromium.org/p/chromium/issues/detail?id=1023678
+                        // https://bugs.chromium.org/p/chromium/issues/detail?id=1050635
+
+                        //We encountered the issue only with some (and not other) videos, but possibly not limited to other file types
+                        return;
+                    }
+
+                    closeDialog(currentActivity);
+                }
+
+                @TargetApi(android.os.Build.VERSION_CODES.M)
+                @Override
+                public void onReceivedError(WebView view, WebResourceRequest req, WebResourceError rerr) {
+                    onReceivedError(view, rerr.getErrorCode(), rerr.getDescription().toString(), req.getUrl().toString());
+                }
+
+            });
+
+            wv.loadUrl(IN_APP_RENDERER_URL);
+        } catch (Exception e) {
+            Kumulos.log(TAG, e.getMessage());
+        }
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -343,9 +343,9 @@ class InAppMessagePresenter {
 
     private static void closeDialog(Activity dialogActivity) {
         if (dialog != null) {
-            unsetStatusBarColorForDialog(dialogActivity);
             dialog.setOnKeyListener(null);
             dialog.dismiss();
+            unsetStatusBarColorForDialog(dialogActivity);
         }
         dialog = null;
         wv = null;

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -259,8 +259,9 @@ class InAppMessagePresenter {
         wv.post(new Runnable() {
             @Override
             public void run() {
-                InAppMessage message = messageQueue.get(0);
-                messageQueue.remove(0);
+                if (!messageQueue.isEmpty()){
+                    messageQueue.remove(0);
+                }
 
                 presentMessageToClient();
             }


### PR DESCRIPTION
### Description of Changes

Fixes of very rare bugs:
1) dialog reference is null, even though checked before. 
```
Caused by java.lang.NullPointerException Attempt to invoke virtual method 'void android.app.Dialog.setOnKeyListener(android.content.DialogInterface$OnKeyListener)' on a null object reference
com.kumulos.android.InAppMessagePresenter.closeDialog (InAppMessagePresenter.java:347)
```

Clarity with threads in InAppMessagePresenter, add annotations. Run most functions on UIThread (as before) and make sure dialog is always closed on UI thread -- different threads setting it to null was the reason for the exception.

2) Index out of bounds exception, even though shouldn't be

```
Fatal Exception: java.lang.IndexOutOfBoundsException
Index: 0, Size: 0
java.util.ArrayList.get (ArrayList.java:437)
com.kumulos.android.InAppMessagePresenter$2.run (InAppMessagePresenter.java:262)
```

Perhaps the reason is messageQueue being accessed from multiple threads. Make sure it's always read or written from ui thread

3) WebView is null when Runnable executed

```
Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'void android.webkit.WebView.evaluateJavascript(java.lang.String, android.webkit.ValueCallback)' on a null object reference

com.kumulos.android.InAppMessagePresenter$4.run (InAppMessagePresenter.java:315)
```

`myView.post(new Runnable(){})` adds runnable to the MessageQueue of UI thread. If this queue is busy, it [may happen](https://stackoverflow.com/questions/50857364/can-a-post-runnable-get-a-null-reference-on-the-view-it-was-run-on) that myView reference is null when the Runnable runs. In all cases where this happens posted work is useless, so, early return.


### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] ~~Detail any breaking changes. Breaking changes require a new major version number~~
- [ ] ~~Check `./gradlew assemble` passes w/ no errors~~

Bump versions in:

- [ ] ~~README.md~~

Release: N/A will merge to #60 and release from there

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
