### PR TITLE
Revert specification of FCM library dependency as a range

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.7.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.7.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.7.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.7.1'
 }
 ```
 

--- a/kumulos/build.gradle
+++ b/kumulos/build.gradle
@@ -29,15 +29,14 @@ android {
     }
 }
 
-
-def firebaseMessagingVersionRange = '[19.0.0, 22.99.99]'
 dependencies {
     testImplementation 'junit:junit:4.12'
+    // Use 3.12.x tree as long as possible (EOL Dec 2021) to keep minSdk 16
     implementation 'com.squareup.okhttp3:okhttp:3.12.13'
     implementation 'ch.acra:acra-http:5.5.0'
     implementation 'org.codehaus.jackson:jackson-mapper-asl:1.8.5'
     implementation 'androidx.work:work-runtime:2.5.0'
-    implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersionRange"
+    implementation 'com.google.firebase:firebase-messaging:21.0.1'
     compileOnly 'com.huawei.hms:push:4.0.3.300'
 }
 


### PR DESCRIPTION
### Description of Changes

Range version checking does not work correctly when the Google Services gradle plugin is applied to consumer
app projects. This seems to be a bug/limitation in the Google Services gradle plugin logic.

This results in an error that can only be resolved by disabling version checking, which defeats the purpose
of supporting ranges of compatible versions of the FCM library.

As the Firebase libraries are moving towards Bill of Materials (BoM) specifications for dependency versioning,
revert our previous change in favour of supporting BoM more explicitly in an upcoming release.

See #60 for context on our addition of the version range for FCM.

Note this SDK still supports FCM versions 19 - 22 at runtime if resolution is different in the consumer project.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
