### PR TITLE
Use Firebase BoM

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ dependencies {
     // Kumulos debug & release libraries
     debugImplementation 'com.kumulos.android:kumulos-android-debug:12.0.0'
     releaseImplementation 'com.kumulos.android:kumulos-android-release:12.0.0'
+
+    // Add firebase-messaging dep using BoM to get compatible version
+    // of Android FCM push gateway library for Kumulos to retrieve
+    // FCM push tokens.
+    implementation platform('com.google.firebase:firebase-bom:28.2.0')
+    implementation 'com.google.firebase:firebase-messaging'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:11.7.1'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:11.7.1'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:12.0.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:12.0.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
         maven {
             url 'http://developer.huawei.com/repo/'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 16 12:22:09 GMT 2021
+#Fri Jul 02 18:06:27 EEST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/kumulos/build.gradle
+++ b/kumulos/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     implementation 'ch.acra:acra-http:5.5.0'
     implementation 'org.codehaus.jackson:jackson-mapper-asl:1.8.5'
     implementation 'androidx.work:work-runtime:2.5.0'
-    implementation 'com.google.firebase:firebase-messaging:21.0.1'
     compileOnly 'com.huawei.hms:push:4.0.3.300'
+    compileOnly 'com.google.firebase:firebase-messaging:22.0.0'
 }
 
 ext {

--- a/kumulos/build.gradle
+++ b/kumulos/build.gradle
@@ -5,7 +5,7 @@ def releaseVersion = System.getenv("RELEASE_VERSION") as String ?: "0.0.0"
 
 android {
     compileSdkVersion 30
-    buildToolsVersion '29.0.3'
+    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
### Description of Changes

Let SDK consumers set firebase messaging version they want. Suggested way is BoM -- consumers would need to add following lines to app-level build.gradle.
```
 implementation platform('com.google.firebase:firebase-bom:28.2.0')
 implementation 'com.google.firebase:firebase-messaging'
```

We support APIs in FM range [19, 22.99.99] which corresponds to BoM versions [20.0.0, 28.2.0]

### Breaking Changes

Consumers have to add additional Firebase Messaging dependencies, or application would crash at runtime / push won't work

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
