### PR TITLE
Add Banner type push notifications and support selection of custom notification channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:12.0.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:12.0.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:12.1.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:12.1.0'
 
     // Add firebase-messaging dep using BoM to get compatible version
     // of Android FCM push gateway library for Kumulos to retrieve

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -45,8 +45,8 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
     static final String EXTRAS_KEY_TICKLE_ID = "com.kumulos.inapp.tickle.id";
     static final String EXTRAS_KEY_BUTTON_ID = "com.kumulos.push.message.button.id";
 
-    public static final String DEFAULT_CHANNEL_ID = "kumulos_general_v3";
-    public static final String IMPORTANT_CHANNEL_ID = "kumulos_important_v1";
+    static final String DEFAULT_CHANNEL_ID = "kumulos_general_v3";
+    static final String IMPORTANT_CHANNEL_ID = "kumulos_important_v1";
     protected static final String KUMULOS_NOTIFICATION_TAG = "kumulos";
 
 

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -309,7 +309,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
             this.channelSetup(notificationManager);
 
-            notificationBuilder = new Notification.Builder(context, pushMessage.getCategory());
+            notificationBuilder = new Notification.Builder(context, pushMessage.getChannel());
         }
         else {
             notificationBuilder = new Notification.Builder(context);
@@ -317,7 +317,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
         KumulosConfig config = Kumulos.getConfig();
         int icon = config != null ? config.getNotificationSmallIconId() : KumulosConfig.DEFAULT_NOTIFICATION_ICON_ID;
-        int priority = pushMessage.getCategory().equals(IMPORTANT_CHANNEL_ID) ? Notification.PRIORITY_MAX : Notification.PRIORITY_DEFAULT;
+        int priority = pushMessage.getChannel().equals(IMPORTANT_CHANNEL_ID) ? Notification.PRIORITY_MAX : Notification.PRIORITY_DEFAULT;
 
         notificationBuilder
                 .setSmallIcon(icon)

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -309,7 +309,12 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
             this.channelSetup(notificationManager);
 
-            notificationBuilder = new Notification.Builder(context, pushMessage.getChannel());
+            if (notificationManager.getNotificationChannel(pushMessage.getChannel()) == null) {
+                notificationBuilder = new Notification.Builder(context, DEFAULT_CHANNEL_ID);
+            }
+            else {
+                notificationBuilder = new Notification.Builder(context, pushMessage.getChannel());
+            }
         }
         else {
             notificationBuilder = new Notification.Builder(context);

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -45,7 +45,8 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
     static final String EXTRAS_KEY_TICKLE_ID = "com.kumulos.inapp.tickle.id";
     static final String EXTRAS_KEY_BUTTON_ID = "com.kumulos.push.message.button.id";
 
-    private static final String DEFAULT_CHANNEL_ID = "kumulos_general_v3";
+    public static final String DEFAULT_CHANNEL_ID = "kumulos_general_v3";
+    public static final String IMPORTANT_CHANNEL_ID = "kumulos_important_v1";
     protected static final String KUMULOS_NOTIFICATION_TAG = "kumulos";
 
 
@@ -306,17 +307,9 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 return null;
             }
 
-            NotificationChannel channel = notificationManager.getNotificationChannel(DEFAULT_CHANNEL_ID);
-            if (null == channel) {
-                this.clearOldChannels(notificationManager);
+            this.channelSetup(notificationManager);
 
-                channel = new NotificationChannel(DEFAULT_CHANNEL_ID, "General", NotificationManager.IMPORTANCE_DEFAULT);
-                channel.setSound(null, null);
-                channel.setVibrationPattern(new long[]{0, 250, 250, 250});
-                notificationManager.createNotificationChannel(channel);
-            }
-
-            notificationBuilder = new Notification.Builder(context, DEFAULT_CHANNEL_ID);
+            notificationBuilder = new Notification.Builder(context, pushMessage.getCategory());
         }
         else {
             notificationBuilder = new Notification.Builder(context);
@@ -324,6 +317,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
         KumulosConfig config = Kumulos.getConfig();
         int icon = config != null ? config.getNotificationSmallIconId() : KumulosConfig.DEFAULT_NOTIFICATION_ICON_ID;
+        int priority = pushMessage.getCategory().equals(IMPORTANT_CHANNEL_ID) ? Notification.PRIORITY_MAX : Notification.PRIORITY_DEFAULT;
 
         notificationBuilder
                 .setSmallIcon(icon)
@@ -331,7 +325,8 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 .setContentText(pushMessage.getMessage())
                 .setAutoCancel(true)
                 .setContentIntent(pendingOpenIntent)
-                .setDeleteIntent(pendingDismissedIntent);
+                .setDeleteIntent(pendingDismissedIntent)
+                .setPriority(priority);
 
         this.maybeAddSound(context, notificationBuilder, notificationManager, pushMessage);
 
@@ -354,6 +349,34 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
             return null;
         }
         return notificationBuilder.build();
+    }
+
+    private void channelSetup(NotificationManager notificationManager) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+
+        NotificationChannel channel = notificationManager.getNotificationChannel(DEFAULT_CHANNEL_ID);
+        NotificationChannel importantChannel = notificationManager.getNotificationChannel(IMPORTANT_CHANNEL_ID);
+
+        //- Signalling a change / update to SDK
+        if (null == channel || null == importantChannel) {
+            this.clearOldChannels(notificationManager);
+        }
+
+        if (null == channel) {
+            channel = new NotificationChannel(DEFAULT_CHANNEL_ID, "General", NotificationManager.IMPORTANCE_DEFAULT);
+            channel.setSound(null, null);
+            channel.setVibrationPattern(new long[]{0, 250, 250, 250});
+            notificationManager.createNotificationChannel(channel);
+        }
+
+        if (null == importantChannel) {
+            channel = new NotificationChannel(IMPORTANT_CHANNEL_ID, "Important", NotificationManager.IMPORTANCE_HIGH);
+            channel.setSound(null, null);
+            channel.setVibrationPattern(new long[]{0, 250, 250, 250});
+            notificationManager.createNotificationChannel(channel);
+        }
     }
 
     private PendingIntent getPushIntent(Context context, PushMessage pushMessage, String action){

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -322,7 +322,6 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
         KumulosConfig config = Kumulos.getConfig();
         int icon = config != null ? config.getNotificationSmallIconId() : KumulosConfig.DEFAULT_NOTIFICATION_ICON_ID;
-        int priority = pushMessage.getChannel().equals(IMPORTANT_CHANNEL_ID) ? Notification.PRIORITY_MAX : Notification.PRIORITY_DEFAULT;
 
         notificationBuilder
                 .setSmallIcon(icon)
@@ -330,8 +329,12 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
                 .setContentText(pushMessage.getMessage())
                 .setAutoCancel(true)
                 .setContentIntent(pendingOpenIntent)
-                .setDeleteIntent(pendingDismissedIntent)
-                .setPriority(priority);
+                .setDeleteIntent(pendingDismissedIntent);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            int priority = pushMessage.getChannel().equals(IMPORTANT_CHANNEL_ID) ? Notification.PRIORITY_MAX : Notification.PRIORITY_DEFAULT;
+            notificationBuilder.setPriority(priority);
+        }
 
         this.maybeAddSound(context, notificationBuilder, notificationManager, pushMessage);
 

--- a/kumulos/src/main/java/com/kumulos/android/PushMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushMessage.java
@@ -39,6 +39,7 @@ public final class PushMessage implements Parcelable {
     String sound;
     private final @Nullable
     String collapseKey;
+    private final String channel;
 
     /**
      * package
@@ -65,6 +66,7 @@ public final class PushMessage implements Parcelable {
         this.buttons = buttons;
         this.sound = sound;
         this.collapseKey = collapseKey;
+        this.channel = this.getChannel(data);
     }
 
     private PushMessage(Parcel in) {
@@ -101,6 +103,26 @@ public final class PushMessage implements Parcelable {
 
         sound = in.readString();
         collapseKey = in.readString();
+        channel = in.readString();
+    }
+
+    private String getChannel(JSONObject data) {
+        String customChannel = data.optString("k.channel");
+        String notificationType = data.optString("k.notificationType");
+
+        if (customChannel != null) {
+            return customChannel;
+        }
+
+        if (notificationType == null) {
+            return PushBroadcastReceiver.DEFAULT_CHANNEL_ID;
+        }
+
+        if (notificationType.equals("important")) {
+            return PushBroadcastReceiver.IMPORTANT_CHANNEL_ID;
+        }
+
+        return PushBroadcastReceiver.DEFAULT_CHANNEL_ID;
     }
 
     private Integer getTickleId(JSONObject data) {
@@ -159,6 +181,7 @@ public final class PushMessage implements Parcelable {
         dest.writeString(buttonsString);
         dest.writeString(sound);
         dest.writeString(collapseKey);
+        dest.writeString(channel);
     }
 
     public int getId() {
@@ -221,4 +244,5 @@ public final class PushMessage implements Parcelable {
         return this.collapseKey;
     }
 
+    public String getChannel() { return channel; }
 }

--- a/kumulos/src/main/java/com/kumulos/android/PushMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushMessage.java
@@ -110,15 +110,11 @@ public final class PushMessage implements Parcelable {
         String customChannel = data.optString("k.channel");
         String notificationType = data.optString("k.notificationType");
 
-        if (customChannel != null) {
+        if (!TextUtils.isEmpty(customChannel)) {
             return customChannel;
         }
 
-        if (notificationType == null) {
-            return PushBroadcastReceiver.DEFAULT_CHANNEL_ID;
-        }
-
-        if (notificationType.equals("important")) {
+        if (!TextUtils.isEmpty(notificationType) && notificationType.equals("important")) {
             return PushBroadcastReceiver.IMPORTANT_CHANNEL_ID;
         }
 


### PR DESCRIPTION
### Description of Changes

The Kumulos push API now supports the mutually exclusive keys 
- notificationType: Hint to the SDK whether a notification should default to the tray or a banner (priority default or max respectively), this is automatic and handled between the Kumulos push pipeline and the SDK.

- notificationChannel: If the app developer has setup specific channels for content then setting this key will forward it to the end consumer and is readable on the PushMessage object.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
