### PR TITLE
Fix ANR when loading push media over slow/unstable connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:12.0.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:12.0.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:12.1.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:12.1.1'
 
     // Add firebase-messaging dep using BoM to get compatible version
     // of Android FCM push gateway library for Kumulos to retrieve

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -507,9 +507,10 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
         private final PushMessage pushMessage;
         private final PendingResult pendingResult;
 
-        //Theoretical time limit for BroadcastReceiver's bg execution is 30s. Leave 5s for connection etc.
+        //Theoretical time limit for BroadcastReceiver's bg execution is 30s. Leave 6s for connection.
         //Practically ANR doesnt happen with even bigger 40+s timeouts.
-        private final int READ_TIMEOUT = 25000;
+        private final int READ_TIMEOUT = 24000;
+        private final int CONNECTION_TIMEOUT = 6000;
 
         LoadNotificationPicture(Context context, PendingResult pendingResult, Notification.Builder builder, PushMessage pushMessage) {
             super();
@@ -538,6 +539,7 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
                 HttpURLConnection connection = (HttpURLConnection) url.openConnection();
                 connection.setDoInput(true);
+                connection.setConnectTimeout(CONNECTION_TIMEOUT);
                 connection.setReadTimeout(READ_TIMEOUT);
 
                 connection.connect();

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 
 import androidx.annotation.Nullable;
@@ -470,10 +471,14 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
     }
 
     private class LoadNotificationPicture extends AsyncTask<Void, Void, Bitmap> {
-        private Notification.Builder builder;
-        private Context context;
-        private PushMessage pushMessage;
-        private PendingResult pendingResult;
+        private final Notification.Builder builder;
+        private final Context context;
+        private final PushMessage pushMessage;
+        private final PendingResult pendingResult;
+
+        //Theoretical time limit for BroadcastReceiver's bg execution is 30s. Leave 5s for connection etc.
+        //Practically ANR doesnt happen with even bigger 40+s timeouts.
+        private final int READ_TIMEOUT = 25000;
 
         LoadNotificationPicture(Context context, PendingResult pendingResult, Notification.Builder builder, PushMessage pushMessage) {
             super();
@@ -502,14 +507,19 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
 
                 HttpURLConnection connection = (HttpURLConnection) url.openConnection();
                 connection.setDoInput(true);
+                connection.setReadTimeout(READ_TIMEOUT);
+
                 connection.connect();
                 in = connection.getInputStream();
                 return BitmapFactory.decodeStream(in);
             } catch (MalformedURLException e) {
                 e.printStackTrace();
+            } catch(SocketTimeoutException e){
+                e.printStackTrace();
             } catch (IOException e) {
                 e.printStackTrace();
             }
+
             return null;
         }
 
@@ -518,6 +528,9 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
             super.onPostExecute(result);
 
             if (result == null){
+                Notification notification = this.builder.build();
+                PushBroadcastReceiver.this.showNotification(this.context, this.pushMessage, notification);
+
                 pendingResult.finish();
                 return;
             }


### PR DESCRIPTION
### Description of Changes

If loading notification picture takes long (probably at least over 30 seconds), BroadcastReceiver hits background execution time limit and system considers the app non-responsive. Slow loading may be due to connection or the pic being resized to huge dimensions.

1) Add 24s timeout for read, 6s timeout for connection
2) if picture failed loading still show notification without the picture

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)
