### PR TITLE
Fix in-app buttons launching URLs on apps targeting API level 30+

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:12.1.2'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:12.1.2'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:12.1.3'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:12.1.3'
 
     // Add firebase-messaging dep using BoM to get compatible version
     // of Android FCM push gateway library for Kumulos to retrieve

--- a/kumulos/src/main/AndroidManifest.xml
+++ b/kumulos/src/main/AndroidManifest.xml
@@ -4,4 +4,18 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application />
+
+    <!-- https://developer.android.com/training/package-visibility/use-cases#check-browser-available -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="http" />
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
### Description of Changes

Due to package visibility level changes, appst declare which queries for intents they plan to issue to the system.

Declare `ACTION_VIEW` queries for both `http://` and `https://` schemes.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [x] Squash and merge to master
- [x] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)

Post Release:

Update docs site with correct version number references

- [x] https://docs.kumulos.com/developer-guide/sdk-reference/android/
- [x] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [x] https://docs.kumulos.com/developer-guide/sdk-reference/android/#changelog
