### PR TITLE
Refactor InAppDeepLinkHandlerInterface to expose in-app message data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:12.1.3'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:12.1.3'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:13.0.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:13.0.0'
 
     // Add firebase-messaging dep using BoM to get compatible version
     // of Android FCM push gateway library for Kumulos to retrieve

--- a/kumulos/src/main/java/com/kumulos/android/InAppContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppContract.java
@@ -262,6 +262,7 @@ class InAppContract {
                     InAppMessageTable.COL_ID,
                     InAppMessageTable.COL_PRESENTED_WHEN,
                     InAppMessageTable.COL_CONTENT_JSON,
+                    InAppMessageTable.COL_DATA_JSON,
                     InAppMessageTable.COL_READ_AT,
                     InAppMessageTable.COL_INBOX_CONFIG_JSON
             };
@@ -274,16 +275,18 @@ class InAppContract {
                 Date readAt = getNullableDate(cursor, InAppMessageTable.COL_READ_AT);
                 JSONObject content = null;
                 JSONObject inbox = null;
+                JSONObject data = null;
 
                 try {
                     content = getNullableJsonObject(cursor, InAppMessageTable.COL_CONTENT_JSON);
+                    data = getNullableJsonObject(cursor, InAppMessageTable.COL_DATA_JSON);
                     inbox = getNullableJsonObject(cursor, InAppMessageTable.COL_INBOX_CONFIG_JSON);
                 } catch (JSONException e) {
                     Kumulos.log(TAG, e.getMessage());
                     continue;
                 }
 
-                InAppMessage m = new InAppMessage(inAppId, presentedWhen, content, inbox, readAt);
+                InAppMessage m = new InAppMessage(inAppId, presentedWhen, content, data, inbox, readAt);
                 itemsToPresent.add(m);
             }
 
@@ -423,7 +426,7 @@ class InAppContract {
                     i.setSentAt(sentAt);
                     i.setData(data);
 
-                    if (inboxConfig != null){
+                    if (inboxConfig != null) {
                         i.setTitle(inboxConfig.getString("title"));
                         i.setSubtitle(inboxConfig.getString("subtitle"));
                         if (!inboxConfig.isNull("imagePath")) {
@@ -465,7 +468,13 @@ class InAppContract {
             try {
                 SQLiteDatabase db = dbHelper.getReadableDatabase();
 
-                String[] projection = {InAppMessageTable.COL_ID, InAppMessageTable.COL_CONTENT_JSON, InAppMessageTable.COL_READ_AT, InAppMessageTable.COL_INBOX_CONFIG_JSON};
+                String[] projection = {
+                        InAppMessageTable.COL_ID,
+                        InAppMessageTable.COL_CONTENT_JSON,
+                        InAppMessageTable.COL_DATA_JSON,
+                        InAppMessageTable.COL_READ_AT,
+                        InAppMessageTable.COL_INBOX_CONFIG_JSON
+                };
                 String selection = InAppMessageTable.COL_INBOX_CONFIG_JSON + " IS NOT NULL AND " + InAppMessageTable.COL_ID + " = ?";
                 String[] selectionArgs = {mId + ""};
 
@@ -474,6 +483,7 @@ class InAppContract {
                 if (cursor.moveToFirst()) {
                     inboxMessage = new InAppMessage(mId,
                             getNullableJsonObject(cursor, InAppMessageTable.COL_CONTENT_JSON),
+                            getNullableJsonObject(cursor, InAppMessageTable.COL_DATA_JSON),
                             getNullableJsonObject(cursor, InAppMessageTable.COL_INBOX_CONFIG_JSON),
                             getNullableDate(cursor, InAppMessageTable.COL_READ_AT));
                 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppDeepLinkHandlerInterface.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppDeepLinkHandlerInterface.java
@@ -2,14 +2,44 @@ package com.kumulos.android;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.json.JSONObject;
 
 public interface InAppDeepLinkHandlerInterface {
     /**
      * Override to change the behaviour of button deep link. Default none
      *
-     * @param data deep link
-     * @return
+     * @param buttonPress Data from the button's deep link, along with any in-app message data payload
      */
-    void handle(Context context, JSONObject data);
+    void handle(Context context, InAppButtonPress buttonPress);
+
+    class InAppButtonPress {
+        @NonNull
+        private final JSONObject deepLinkData;
+        private final int messageId;
+        @Nullable
+        private final JSONObject messageData;
+
+        InAppButtonPress(@NonNull JSONObject deepLinkData, int messageId, @Nullable JSONObject messageData) {
+            this.deepLinkData = deepLinkData;
+            this.messageId = messageId;
+            this.messageData = messageData;
+        }
+
+        @NonNull
+        public JSONObject getDeepLinkData() {
+            return deepLinkData;
+        }
+
+        public int getMessageId() {
+            return messageId;
+        }
+
+        @Nullable
+        public JSONObject getMessageData() {
+            return messageData;
+        }
+    }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessage.java
@@ -68,17 +68,19 @@ class InAppMessage {
         }
     }
 
-    InAppMessage(int inAppId, String presentedWhen, JSONObject content, @Nullable JSONObject inbox, @Nullable Date readAt) {
+    InAppMessage(int inAppId, String presentedWhen, JSONObject content, @Nullable JSONObject data, @Nullable JSONObject inbox, @Nullable Date readAt) {
         this.inAppId = inAppId;
         this.presentedWhen = presentedWhen;
         this.content = content;
+        this.data = data;
         this.inbox = inbox;
         this.readAt = readAt;
     }
 
-    InAppMessage(int inAppId, JSONObject content, @Nullable JSONObject inbox, @Nullable Date readAt) {
+    InAppMessage(int inAppId, JSONObject content, @Nullable JSONObject data, @Nullable JSONObject inbox, @Nullable Date readAt) {
         this.inAppId = inAppId;
         this.content = content;
+        this.data = data;
         this.inbox = inbox;
         this.readAt = readAt;
     }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import androidx.annotation.AnyThread;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.UiThread;
 
@@ -66,6 +67,16 @@ class InAppMessagePresenter {
         }
 
         currentActivity.runOnUiThread(() -> presentMessagesOnUiThread(currentActivity, itemsToPresent, tickleIds));
+    }
+
+    @UiThread
+    @Nullable
+    static InAppMessage getCurrentMessage() {
+        if (0 == messageQueue.size()) {
+            return null;
+        }
+
+        return messageQueue.get(0);
     }
 
     @UiThread

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessageService.java
@@ -409,6 +409,7 @@ class InAppMessageService {
                         InAppContract.InAppMessageTable.COL_ID,
                         InAppContract.InAppMessageTable.COL_PRESENTED_WHEN,
                         InAppContract.InAppMessageTable.COL_CONTENT_JSON,
+                        InAppContract.InAppMessageTable.COL_DATA_JSON,
                         InAppContract.InAppMessageTable.COL_READ_AT,
                         InAppContract.InAppMessageTable.COL_INBOX_CONFIG_JSON
                 };
@@ -424,11 +425,12 @@ class InAppMessageService {
                 while (cursor.moveToNext()) {
                     int inAppId = cursor.getInt(cursor.getColumnIndexOrThrow(InAppContract.InAppMessageTable.COL_ID));
                     String content = cursor.getString(cursor.getColumnIndexOrThrow(InAppContract.InAppMessageTable.COL_CONTENT_JSON));
+                    JSONObject data = InAppContract.getNullableJsonObject(cursor, InAppContract.InAppMessageTable.COL_DATA_JSON);
                     String presentedWhen = cursor.getString(cursor.getColumnIndexOrThrow(InAppContract.InAppMessageTable.COL_PRESENTED_WHEN));
                     Date readAt = InAppContract.getNullableDate(cursor, InAppContract.InAppMessageTable.COL_READ_AT);
                     JSONObject inbox = InAppContract.getNullableJsonObject(cursor, InAppContract.InAppMessageTable.COL_INBOX_CONFIG_JSON);
 
-                    InAppMessage m = new InAppMessage(inAppId, presentedWhen, new JSONObject(content), inbox, readAt);
+                    InAppMessage m = new InAppMessage(inAppId, presentedWhen, new JSONObject(content), data, inbox, readAt);
                     itemsToPresent.add(m);
                 }
                 cursor.close();


### PR DESCRIPTION
### Description of Changes

Breaking change:

- `InAppDeepLinkHandlerInterface#handle(Context,JSONObject)` is now
  `InAppDeepLinkHandlerInterface#handle(Context,InAppButtonPress)`

The `InAppButtonPress` model contains the original `JSONObject` in the
`deepLinkData` field, and additionally offers the in-app message's ID and
(optional) data field.

Changes throughout support selecting the data field from the database
during presentation / inbox operations to ensure it is available to
the button handler.

![Screenshot from 2021-09-07 15-50-38](https://user-images.githubusercontent.com/1305158/132366718-7d63df95-3515-41f8-b947-24286f2725b7.png)

Changes to threading were introduced to allow access to the message presentation queue from the button handler. All button actions have been regression tested.

### Breaking Changes

- `InAppDeepLinkHandlerInterface#handle(Context,JSONObject)` is now
  `InAppDeepLinkHandlerInterface#handle(Context,InAppButtonPress)`

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)

Post Release:

Update docs site with correct version number references

- [x] https://docs.kumulos.com/developer-guide/sdk-reference/android/
- [x] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [x] https://docs.kumulos.com/developer-guide/sdk-reference/android/#changelog
