### PR TITLE
Fix rare edge case leading to infinite in-app spinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:13.0.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:13.0.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:13.0.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:13.0.1'
 
     // Add firebase-messaging dep using BoM to get compatible version
     // of Android FCM push gateway library for Kumulos to retrieve


### PR DESCRIPTION
### Description of Changes

In rare cases, the in-app renderer spinner could become stuck on the
screen.

This could happen due to failed network requests for critical assets
(HTML,CSS,JS from iar.app.delivery).

Occasionally on some devices it seems the WebView's cache can become
inconsistent and end up with a cached index.html requesting old CSS/JS
asset files.

These old asset requests result in 404s from the CDN.  In turn, the load
of the renderer never completes and the READY message is not received by
the host.

To address this, the following changes have been made:

- Change WebView cache strategy to LOAD_DEFAULT instead of
  LOAD_CACHE_ELSE_NETWORK (this means that cached assets will expire
based on server cache headers rather than keep being used -- limit the
window of exposure for stale HTML/CSS/JS)
- Implement WebViewClient#onReceivedHttpError() to clean up the spinner
  & end presentation when any critical resource fails to load
- Evict the WebView's cache if any of the failures for critical assets
  were 404s

Additionally to improve robustness the following was undertaken:

- Implement onReceivedSslError to clean up the spinner if any cert
  errors happen (unlikely but possible)
- Implement onRenderProcessGone to clean up and allow app to keep
  running instead of crashing if the WebView instance internally crashes
- Show the spinner prior to starting to load the WebView content (this
  means any delay accessing the CDN is reflected with a loading
indicator instead of the tansparent dialog invisibly preventing app
interaction)

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)

Post Release:

Update docs site with correct version number references

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/
- [ ] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/#changelog
