### PR TITLE
Ensure in-app view guards are applied on UI thread

### DIFF
--- a/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
@@ -14,6 +14,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 class InAppJavaScriptInterface {
 
@@ -30,6 +31,7 @@ class InAppJavaScriptInterface {
 
     @JavascriptInterface
     public void postClientMessage(String msg) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "postClientMessage"));
         String messageType = null;
         JSONObject data = null;
         try {
@@ -40,9 +42,11 @@ class InAppJavaScriptInterface {
             Log.d(TAG, "Incorrect message format: " + msg);
             return;
         }
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "postClientMessage received %s", messageType));
 
         final Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
         if (null == currentActivity) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "postClientMessage currentActivity == null"));
             return;
         }
 

--- a/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
@@ -54,7 +54,7 @@ class InAppJavaScriptInterface {
                 InAppMessagePresenter.messageOpened(currentActivity);
                 return;
             case "MESSAGE_CLOSED":
-                InAppMessagePresenter.messageClosed();
+                InAppMessagePresenter.messageClosed(currentActivity);
                 return;
             case "EXECUTE_ACTIONS":
                 List<ExecutableAction> actions = this.parseButtonActionData(data);

--- a/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
@@ -94,10 +94,14 @@ class InAppJavaScriptInterface {
         for (ExecutableAction action : actions) {
             switch (action.getType()) {
                 case BUTTON_ACTION_OPEN_URL:
+                    InAppMessagePresenter.cancelCurrentPresentationQueue(currentActivity);
+
                     this.openUrl(currentActivity, action.getUrl());
                     return;
                 case BUTTON_ACTION_DEEP_LINK:
                     if (null != KumulosInApp.inAppDeepLinkHandler) {
+                        InAppMessagePresenter.cancelCurrentPresentationQueue(currentActivity);
+
                         KumulosInApp.inAppDeepLinkHandler.handle(KumulosInApp.application,
                                 new InAppDeepLinkHandlerInterface.InAppButtonPress(
                                         action.getDeepLink(),
@@ -108,9 +112,13 @@ class InAppJavaScriptInterface {
                     }
                     return;
                 case BUTTON_ACTION_REQUEST_APP_STORE_RATING:
+                    InAppMessagePresenter.cancelCurrentPresentationQueue(currentActivity);
+
                     this.openPlayStore(currentActivity);
                     return;
                 case BUTTON_ACTION_PUSH_REGISTER:
+                    InAppMessagePresenter.cancelCurrentPresentationQueue(currentActivity);
+
                     Kumulos.pushRegister(currentActivity);
                     return;
             }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -35,6 +35,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import androidx.annotation.AnyThread;
 import androidx.annotation.NonNull;
@@ -65,9 +66,11 @@ class InAppMessagePresenter {
 
     @AnyThread
     static synchronized void presentMessages(List<InAppMessage> itemsToPresent, List<Integer> tickleIds) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "presentMessages requesting display of %d messages", itemsToPresent.size()));
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
 
         if (currentActivity == null) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "presentMessages currentActivity == null"));
             return;
         }
 
@@ -86,7 +89,9 @@ class InAppMessagePresenter {
 
     @UiThread
     private static void presentMessagesOnUiThread(Activity currentActivity, List<InAppMessage> itemsToPresent, List<Integer> tickleIds) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "presentMessagesOnUiThread requesting display of %d messages", itemsToPresent.size()));
         if (currentActivity == null) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "presentMessagesOnUiThread currentActivity == null"));
             return;
         }
 
@@ -110,6 +115,7 @@ class InAppMessagePresenter {
 
         Activity dialogActivity = getDialogActivity(dialog.getContext());
         if (dialogActivity.hashCode() != currentActivity.hashCode()) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "presentMessagesOnUiThread changed activity, recreate views"));
             closeDialog(dialogActivity);
             showWebView(currentActivity);
             return;
@@ -118,6 +124,7 @@ class InAppMessagePresenter {
         maybeRefreshFirstMessageInQueue(oldQueue);
 
         if (presentationPendingOnResume) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "presentMessagesOnUiThread pending on resume"));
             presentMessageToClient();
         }
     }
@@ -173,8 +180,10 @@ class InAppMessagePresenter {
 
     @UiThread
     private static void presentMessageToClient() {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "presentMessageToClient msgQueue size=%d", messageQueue.size()));
         Activity currentActivity = AnalyticsContract.ForegroundStateWatcher.getCurrentActivity();
         if (currentActivity == null) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "presentMessageToClient null activity, pending=true, ret"));
             presentationPendingOnResume = true;
 
             return;
@@ -192,6 +201,7 @@ class InAppMessagePresenter {
             return;
         }
 
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "presentMessageToClient show spinner"));
         setSpinnerVisibility(View.VISIBLE);
 
         InAppMessage message = messageQueue.get(0);
@@ -200,8 +210,11 @@ class InAppMessagePresenter {
 
     @AnyThread
     static void clientReady(@NonNull final Activity currentActivity) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "clientReady"));
         currentActivity.runOnUiThread(() -> {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "clientReady->lambda"));
             if (wv == null) {
+                Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "clientReady->lambda, wv==null"));
                 return;
             }
 
@@ -276,7 +289,9 @@ class InAppMessagePresenter {
 
     @AnyThread
     static void messageOpened(Activity activity) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "messageOpened"));
         activity.runOnUiThread(() -> {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "messageOpened->lambda hide spinner"));
             InAppMessageService.handleMessageOpened(activity, messageQueue.get(0));
             setSpinnerVisibility(View.GONE);
         });
@@ -284,8 +299,11 @@ class InAppMessagePresenter {
 
     @AnyThread
     static void messageClosed(@NonNull final Activity currentActivity) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "messageClosed"));
         currentActivity.runOnUiThread(() -> {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "messageClosed->lambda"));
             if (wv == null) {
+                Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "messageClosed->lambda wv == null"));
                 return;
             }
 
@@ -297,7 +315,9 @@ class InAppMessagePresenter {
 
     @UiThread
     static void closeCurrentMessage(@NonNull final Activity activity) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "closeCurrentMessage"));
         if (dialog == null || messageQueue.isEmpty()) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "closeCurrentMessage dialog == null (non-null?=%b) || empty queue (size=%d)", dialog, messageQueue.size()));
             return;
         }
 
@@ -310,14 +330,18 @@ class InAppMessagePresenter {
 
     @UiThread
     private static void setSpinnerVisibility(int visibility) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "setSpinnerVisibility %d", visibility));
         if (spinner != null) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "spinner not null, do it"));
             spinner.setVisibility(visibility);
         }
     }
 
     @UiThread
     private static void sendToClient(String type, JSONObject data) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "sendToClient %s", type));
         if (wv == null) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "sendToClient wv == null"));
             return;
         }
 
@@ -341,11 +365,14 @@ class InAppMessagePresenter {
 
     @UiThread
     static void maybeCloseDialog(Activity stoppedActivity) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "maybeCloseDialog"));
         if (dialog == null) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "maybeCloseDialog dialog == null"));
             return;
         }
         Activity dialogActivity = getDialogActivity(dialog.getContext());
         if (stoppedActivity.hashCode() == dialogActivity.hashCode()) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "maybeCloseDialog same activity, close"));
             closeDialog(stoppedActivity);
         }
     }
@@ -364,7 +391,9 @@ class InAppMessagePresenter {
 
     @UiThread
     private static void closeDialog(Activity dialogActivity) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "closeDialog"));
         if (dialog != null) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "closeDialog dialog != null"));
             dialog.setOnKeyListener(null);
             dialog.dismiss();
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -373,6 +402,7 @@ class InAppMessagePresenter {
         }
 
         if (null != wv) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "closeDialog wv != null"));
             wv.destroy();
         }
 
@@ -435,7 +465,9 @@ class InAppMessagePresenter {
     @SuppressLint({"SetJavaScriptEnabled", "AddJavascriptInterface"})
     @UiThread
     private static void showWebView(@NonNull final Activity currentActivity) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "showWebView"));
         if (dialog != null) {
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "showWebView dialog != null, abort"));
             return;
         }
 
@@ -465,6 +497,7 @@ class InAppMessagePresenter {
                 return true;
             });
             dialog.show();
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "showWebView dialog shown"));
 
             wv = dialog.findViewById(R.id.kumulos_webview);
             spinner = dialog.findViewById(R.id.kumulos_progressBar);
@@ -488,6 +521,7 @@ class InAppMessagePresenter {
             wv.setWebViewClient(new WebViewClient() {
                 @Override
                 public void onPageFinished(WebView view, String url) {
+                    Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "onPageFinished"));
                     view.setBackgroundColor(android.graphics.Color.TRANSPARENT);
                     setStatusBarColorForDialog(currentActivity);
                     super.onPageFinished(view, url);
@@ -557,7 +591,9 @@ class InAppMessagePresenter {
             });
 
             InAppMessagePresenter.setSpinnerVisibility(View.VISIBLE);
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "showWebView spinner shown"));
             wv.loadUrl(IN_APP_RENDERER_URL);
+            Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "showWebView load req"));
         } catch (Exception e) {
             Kumulos.log(TAG, e.getMessage());
         }
@@ -565,6 +601,7 @@ class InAppMessagePresenter {
 
     @UiThread
     public static void cancelCurrentPresentationQueue(@NonNull Activity currentActivity) {
+        Kumulos.log("KUM_IN_APP", String.format(Locale.ENGLISH, "cancelCurrentPresentationQueue"));
         messageQueue.clear();
         closeDialog(currentActivity);
     }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -200,17 +200,13 @@ class InAppMessagePresenter {
     }
 
     @AnyThread
-    static void clientReady(Context context) {
-        if (wv == null) {
-            return;
-        }
-
-        wv.post(() -> {
+    static void clientReady(@NonNull final Activity currentActivity) {
+        currentActivity.runOnUiThread(() -> {
             if (wv == null) {
                 return;
             }
 
-            maybeSetNotchInsets(context);
+            maybeSetNotchInsets(currentActivity);
             presentMessageToClient();
         });
     }
@@ -288,12 +284,8 @@ class InAppMessagePresenter {
     }
 
     @AnyThread
-    static void messageClosed() {
-        if (wv == null) {
-            return;
-        }
-
-        wv.post(() -> {
+    static void messageClosed(@NonNull final Activity currentActivity) {
+        currentActivity.runOnUiThread(() -> {
             if (wv == null) {
                 return;
             }
@@ -304,22 +296,17 @@ class InAppMessagePresenter {
         });
     }
 
-    @AnyThread
-    static void closeCurrentMessage(Activity activity) {
-        if (dialog == null || activity == null) {
+    @UiThread
+    static void closeCurrentMessage(@NonNull final Activity activity) {
+        if (dialog == null || messageQueue.isEmpty()) {
             return;
         }
 
-        activity.runOnUiThread(() -> {
-            if (messageQueue.isEmpty()) {
-                return;
-            }
-            InAppMessage message = messageQueue.get(0);
+        InAppMessage message = messageQueue.get(0);
 
-            InAppMessagePresenter.sendToClient(HOST_MESSAGE_TYPE_CLOSE_MESSAGE, null);
+        InAppMessagePresenter.sendToClient(HOST_MESSAGE_TYPE_CLOSE_MESSAGE, null);
 
-            InAppMessageService.handleMessageClosed(activity, message);
-        });
+        InAppMessageService.handleMessageClosed(activity, message);
     }
 
     @UiThread
@@ -448,7 +435,7 @@ class InAppMessagePresenter {
 
     @SuppressLint({"SetJavaScriptEnabled", "AddJavascriptInterface"})
     @UiThread
-    private static void showWebView(@NonNull Activity currentActivity) {
+    private static void showWebView(@NonNull final Activity currentActivity) {
         if (dialog != null) {
             return;
         }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -562,4 +562,10 @@ class InAppMessagePresenter {
             Kumulos.log(TAG, e.getMessage());
         }
     }
+
+    @UiThread
+    public static void cancelCurrentPresentationQueue(@NonNull Activity currentActivity) {
+        messageQueue.clear();
+        closeDialog(currentActivity);
+    }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -6,7 +6,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.ContextWrapper;
-import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.net.http.SslError;
 import android.os.Build;
@@ -458,7 +457,7 @@ class InAppMessagePresenter {
             }
 
             LayoutInflater inflater = (LayoutInflater) currentActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-            dialog.setContentView(inflater.inflate(R.layout.dialog_view, null), paramsWebView);
+            dialog.setContentView(inflater.inflate(R.layout.kumulos_dialog_view, null), paramsWebView);
             dialog.setOnKeyListener((arg0, keyCode, event) -> {
                 if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() != KeyEvent.ACTION_DOWN) {
                     InAppMessagePresenter.closeCurrentMessage(currentActivity);
@@ -467,8 +466,8 @@ class InAppMessagePresenter {
             });
             dialog.show();
 
-            wv = dialog.findViewById(R.id.webview);
-            spinner = dialog.findViewById(R.id.progressBar);
+            wv = dialog.findViewById(R.id.kumulos_webview);
+            spinner = dialog.findViewById(R.id.kumulos_progressBar);
 
             int cacheMode = WebSettings.LOAD_DEFAULT;
             if (BuildConfig.DEBUG) {

--- a/kumulos/src/main/res/layout/kumulos_dialog_view.xml
+++ b/kumulos/src/main/res/layout/kumulos_dialog_view.xml
@@ -5,14 +5,14 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/transparent"
-    android:id="@+id/root_view">
+    android:id="@+id/kumulos_root_view">
 
-    <WebView android:id="@+id/webview"
+    <WebView android:id="@+id/kumulos_webview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
     <ProgressBar
-        android:id="@+id/progressBar"
+        android:id="@+id/kumulos_progressBar"
         style="?android:attr/progressBarStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
### Description of Changes

- Prevent stale reads / races causing infinite in-app spinner if view was cleaned up on main thread but guard executed on JS bridge thread.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [ ] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)

Post Release:

Update docs site with correct version number references

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/
- [ ] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/#changelog
