### PR TITLE
In-app spinner fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:13.0.1'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:13.0.1'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:13.0.2'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:13.0.2'
 
     // Add firebase-messaging dep using BoM to get compatible version
     // of Android FCM push gateway library for Kumulos to retrieve

--- a/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
@@ -54,7 +54,7 @@ class InAppJavaScriptInterface {
                 InAppMessagePresenter.messageOpened(currentActivity);
                 return;
             case "MESSAGE_CLOSED":
-                InAppMessagePresenter.messageClosed();
+                InAppMessagePresenter.messageClosed(currentActivity);
                 return;
             case "EXECUTE_ACTIONS":
                 List<ExecutableAction> actions = this.parseButtonActionData(data);

--- a/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
@@ -94,10 +94,14 @@ class InAppJavaScriptInterface {
         for (ExecutableAction action : actions) {
             switch (action.getType()) {
                 case BUTTON_ACTION_OPEN_URL:
+                    InAppMessagePresenter.cancelCurrentPresentationQueue(currentActivity);
+
                     this.openUrl(currentActivity, action.getUrl());
                     return;
                 case BUTTON_ACTION_DEEP_LINK:
                     if (null != KumulosInApp.inAppDeepLinkHandler) {
+                        InAppMessagePresenter.cancelCurrentPresentationQueue(currentActivity);
+
                         KumulosInApp.inAppDeepLinkHandler.handle(KumulosInApp.application,
                                 new InAppDeepLinkHandlerInterface.InAppButtonPress(
                                         action.getDeepLink(),
@@ -108,9 +112,13 @@ class InAppJavaScriptInterface {
                     }
                     return;
                 case BUTTON_ACTION_REQUEST_APP_STORE_RATING:
+                    InAppMessagePresenter.cancelCurrentPresentationQueue(currentActivity);
+
                     this.openPlayStore(currentActivity);
                     return;
                 case BUTTON_ACTION_PUSH_REGISTER:
+                    InAppMessagePresenter.cancelCurrentPresentationQueue(currentActivity);
+
                     Kumulos.pushRegister(currentActivity);
                     return;
             }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -200,17 +200,13 @@ class InAppMessagePresenter {
     }
 
     @AnyThread
-    static void clientReady(Context context) {
-        if (wv == null) {
-            return;
-        }
-
-        wv.post(() -> {
+    static void clientReady(@NonNull final Activity currentActivity) {
+        currentActivity.runOnUiThread(() -> {
             if (wv == null) {
                 return;
             }
 
-            maybeSetNotchInsets(context);
+            maybeSetNotchInsets(currentActivity);
             presentMessageToClient();
         });
     }
@@ -288,12 +284,8 @@ class InAppMessagePresenter {
     }
 
     @AnyThread
-    static void messageClosed() {
-        if (wv == null) {
-            return;
-        }
-
-        wv.post(() -> {
+    static void messageClosed(@NonNull final Activity currentActivity) {
+        currentActivity.runOnUiThread(() -> {
             if (wv == null) {
                 return;
             }
@@ -304,22 +296,17 @@ class InAppMessagePresenter {
         });
     }
 
-    @AnyThread
-    static void closeCurrentMessage(Activity activity) {
-        if (dialog == null || activity == null) {
+    @UiThread
+    static void closeCurrentMessage(@NonNull final Activity activity) {
+        if (dialog == null || messageQueue.isEmpty()) {
             return;
         }
 
-        activity.runOnUiThread(() -> {
-            if (messageQueue.isEmpty()) {
-                return;
-            }
-            InAppMessage message = messageQueue.get(0);
+        InAppMessage message = messageQueue.get(0);
 
-            InAppMessagePresenter.sendToClient(HOST_MESSAGE_TYPE_CLOSE_MESSAGE, null);
+        InAppMessagePresenter.sendToClient(HOST_MESSAGE_TYPE_CLOSE_MESSAGE, null);
 
-            InAppMessageService.handleMessageClosed(activity, message);
-        });
+        InAppMessageService.handleMessageClosed(activity, message);
     }
 
     @UiThread
@@ -448,7 +435,7 @@ class InAppMessagePresenter {
 
     @SuppressLint({"SetJavaScriptEnabled", "AddJavascriptInterface"})
     @UiThread
-    private static void showWebView(@NonNull Activity currentActivity) {
+    private static void showWebView(@NonNull final Activity currentActivity) {
         if (dialog != null) {
             return;
         }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -562,4 +562,10 @@ class InAppMessagePresenter {
             Kumulos.log(TAG, e.getMessage());
         }
     }
+
+    @UiThread
+    public static void cancelCurrentPresentationQueue(@NonNull Activity currentActivity) {
+        messageQueue.clear();
+        closeDialog(currentActivity);
+    }
 }

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessagePresenter.java
@@ -6,7 +6,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.ContextWrapper;
-import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.net.http.SslError;
 import android.os.Build;
@@ -458,7 +457,7 @@ class InAppMessagePresenter {
             }
 
             LayoutInflater inflater = (LayoutInflater) currentActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-            dialog.setContentView(inflater.inflate(R.layout.dialog_view, null), paramsWebView);
+            dialog.setContentView(inflater.inflate(R.layout.kumulos_dialog_view, null), paramsWebView);
             dialog.setOnKeyListener((arg0, keyCode, event) -> {
                 if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() != KeyEvent.ACTION_DOWN) {
                     InAppMessagePresenter.closeCurrentMessage(currentActivity);
@@ -467,8 +466,8 @@ class InAppMessagePresenter {
             });
             dialog.show();
 
-            wv = dialog.findViewById(R.id.webview);
-            spinner = dialog.findViewById(R.id.progressBar);
+            wv = dialog.findViewById(R.id.kumulos_webview);
+            spinner = dialog.findViewById(R.id.kumulos_progressBar);
 
             int cacheMode = WebSettings.LOAD_DEFAULT;
             if (BuildConfig.DEBUG) {

--- a/kumulos/src/main/res/layout/kumulos_dialog_view.xml
+++ b/kumulos/src/main/res/layout/kumulos_dialog_view.xml
@@ -5,14 +5,14 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/transparent"
-    android:id="@+id/root_view">
+    android:id="@+id/kumulos_root_view">
 
-    <WebView android:id="@+id/webview"
+    <WebView android:id="@+id/kumulos_webview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
     <ProgressBar
-        android:id="@+id/progressBar"
+        android:id="@+id/kumulos_progressBar"
         style="?android:attr/progressBarStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
### Description of Changes

Fix cases where in-app spinner could be shown incorrectly:

- Prevent stale reads / races if view was cleaned up on main thread but guard executed on JS bridge thread
- Prefix layout resource IDs
- Cancel current in-app presentation queue when handling a 'terminating' button actions

The issue was most likely to present during in-app deep link navigation, and depending on how deep link handling was implemented.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)

Post Release:

Update docs site with correct version number references

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/
- [ ] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/#changelog
