### PR TITLE
Track event properties with in-app button conversion events

### DIFF
--- a/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppJavaScriptInterface.java
@@ -85,7 +85,7 @@ class InAppJavaScriptInterface {
                     psm.subscribe(currentActivity, new String[]{action.getChannelUuid()});
                     break;
                 case BUTTON_ACTION_TRACK_CONVERSION_EVENT:
-                    Kumulos.trackEventImmediately(currentActivity, action.getEventType(), null);
+                    Kumulos.trackEventImmediately(currentActivity, action.getEventType(), action.getConversionEventData());
                     break;
             }
         }
@@ -164,7 +164,9 @@ class InAppJavaScriptInterface {
                     break;
                 case BUTTON_ACTION_TRACK_CONVERSION_EVENT:
                     String eventType = rawActionData.optString("eventType");
+                    JSONObject eventData = rawActionData.optJSONObject("data");
                     action.setEventType(eventType);
+                    action.setConversionEventData(eventData);
                     break;
                 case BUTTON_ACTION_OPEN_URL:
                     String url = rawActionData.optString("url");
@@ -188,6 +190,7 @@ class InAppJavaScriptInterface {
         String channelUuid;
         String eventType;
         JSONObject deepLink;
+        JSONObject conversionEventData;
 
         void setType(String type) {
             this.type = type;
@@ -199,6 +202,10 @@ class InAppJavaScriptInterface {
 
         void setEventType(String eventType) {
             this.eventType = eventType;
+        }
+
+        void setConversionEventData(JSONObject data) {
+            conversionEventData = data;
         }
 
         void setUrl(String url) {
@@ -223,6 +230,10 @@ class InAppJavaScriptInterface {
 
         String getEventType() {
             return eventType;
+        }
+
+        JSONObject getConversionEventData() {
+            return conversionEventData;
         }
 
         JSONObject getDeepLink() {


### PR DESCRIPTION
### Description of Changes

If a button action from an in-app message specifies data for its
conversion event, pass this data through to the tracked event.

Data will be pre-merged server-side with reporting_meta and user_meta of
the particular message.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

~~Bump versions in:~~

- [ ] README.md

~~Release:~~

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)

Post Release:

Update docs site with correct version number references

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/
- [ ] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/#changelog
