### PR TITLE
Dont set insets when view detached

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:14.0.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:14.0.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:14.0.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:14.0.1'
 
     // Add firebase-messaging dep using BoM to get compatible version
     // of Android FCM push gateway library for Kumulos to retrieve

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessageView.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessageView.java
@@ -19,6 +19,7 @@ import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.Window;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.webkit.JavascriptInterface;
 import android.webkit.RenderProcessGoneDetail;
@@ -437,7 +438,12 @@ class InAppMessageView extends WebViewClient {
             return;
         }
 
-        DisplayCutout displayCutout = window.getDecorView().getRootWindowInsets().getDisplayCutout();
+        WindowInsets insets = window.getDecorView().getRootWindowInsets();
+        if (insets == null){
+            return;
+        }
+
+        DisplayCutout displayCutout = insets.getDisplayCutout();
         if (displayCutout == null) {
             return;
         }


### PR DESCRIPTION
### Description of Changes

`getRootWindowInsets()` returns null when view is detached. Add null check to prevent NullPointerException. Detached view usually means activity is destroyed. 

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)

Post Release:

Update docs site with correct version number references

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/
- [ ] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [x] https://docs.kumulos.com/developer-guide/sdk-reference/android/#changelog
