### PR TITLE
Android 12 bugfix: Check classification status before reading score

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:14.0.1'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:14.0.1'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:14.0.2'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:14.0.2'
 
     // Add firebase-messaging dep using BoM to get compatible version
     // of Android FCM push gateway library for Kumulos to retrieve

--- a/kumulos/src/main/java/com/kumulos/android/DeferredDeepLinkHelper.java
+++ b/kumulos/src/main/java/com/kumulos/android/DeferredDeepLinkHelper.java
@@ -32,6 +32,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
+import static android.content.ClipDescription.CLASSIFICATION_COMPLETE;
 import static android.content.Context.CLIPBOARD_SERVICE;
 
 public class DeferredDeepLinkHelper {
@@ -169,6 +170,11 @@ public class DeferredDeepLinkHelper {
             if (description == null){
                 return null;
             }
+
+            if (description.getClassificationStatus() != CLASSIFICATION_COMPLETE){
+                return null;
+            }
+
             float score = description.getConfidenceScore(TextClassifier.TYPE_URL);
             if (score != 1){
                 return null;


### PR DESCRIPTION
### Description of Changes

Trying to read score when status is CLASSIFICATION_NOT_PERFORMED (This may be the case if the clip does not contain text in its first item, or if the text is too long) or CLASSIFICATION_NOT_COMPLETE (This will be always be the case if the clip has not been copied to clipboard, or if there is no associated clip.) will result in IllegalArgumentException

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [x] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)

Post Release:

Update docs site with correct version number references

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/
- [ ] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/#changelog
