### PR TITLE
Add explicit call to 'sslErrorHandler.cancel()'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ android {
 
 dependencies {
     // Kumulos debug & release libraries
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:14.0.2'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:14.0.2'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:15.0.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:15.0.0'
 
     // Add firebase-messaging dep using BoM to get compatible version
     // of Android FCM push gateway library for Kumulos to retrieve

--- a/kumulos/build.gradle
+++ b/kumulos/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'maven-publish'
 def releaseVersion = System.getenv("RELEASE_VERSION") as String ?: "0.0.0"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         // https://issuetracker.google.com/issues/158695880
         buildConfigField 'String', 'VERSION_NAME', "\"$releaseVersion\""

--- a/kumulos/build.gradle
+++ b/kumulos/build.gradle
@@ -32,7 +32,6 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
     // Use 3.12.x tree as long as possible (EOL Dec 2021) to keep minSdk 16
-    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.squareup.okhttp3:okhttp:3.12.13'
     implementation 'ch.acra:acra-http:5.5.0'
     implementation 'org.codehaus.jackson:jackson-mapper-asl:1.8.5'

--- a/kumulos/build.gradle
+++ b/kumulos/build.gradle
@@ -32,6 +32,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
     // Use 3.12.x tree as long as possible (EOL Dec 2021) to keep minSdk 16
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.squareup.okhttp3:okhttp:3.12.13'
     implementation 'ch.acra:acra-http:5.5.0'
     implementation 'org.codehaus.jackson:jackson-mapper-asl:1.8.5'

--- a/kumulos/src/main/AndroidManifest.xml
+++ b/kumulos/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="com.kumulos.android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application>
         <provider
@@ -10,6 +11,12 @@
             android:exported="false" />
         <activity
             android:name=".PushOpenInvisibleActivity"
+            android:noHistory="true"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.Translucent"
+            android:exported="false" />
+        <activity
+            android:name=".RequestNotificationPermissionActivity"
             android:noHistory="true"
             android:excludeFromRecents="true"
             android:theme="@android:style/Theme.Translucent"

--- a/kumulos/src/main/AndroidManifest.xml
+++ b/kumulos/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
             android:name=".RequestNotificationPermissionActivity"
             android:noHistory="true"
             android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.Translucent"
+            android:theme="@style/Kumulos.Transparent"
             android:exported="false" />
     </application>
 

--- a/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
+++ b/kumulos/src/main/java/com/kumulos/android/AnalyticsContract.java
@@ -43,6 +43,7 @@ final class AnalyticsContract {
     static final String EVENT_TYPE_ASSOCIATE_USER = "k.stats.userAssociated";
     static final String EVENT_TYPE_CLEAR_USER_ASSOCIATION = "k.stats.userAssociationCleared";
     static final String EVENT_TYPE_PUSH_DEVICE_REGISTERED = "k.push.deviceRegistered";
+    static final String EVENT_TYPE_PUSH_NOTIFICATION_ENABLEMENT_CHANGED = "k.push.notificationEnablementChanged";
     static final String EVENT_TYPE_PUSH_DEVICE_UNSUBSCRIBED = "k.push.deviceUnsubscribed";
     static final String EVENT_TYPE_MESSAGE_DISMISSED = "k.message.dismissed";
     static final String EVENT_TYPE_MESSAGE_OPENED = "k.message.opened";

--- a/kumulos/src/main/java/com/kumulos/android/AppStateWatcher.java
+++ b/kumulos/src/main/java/com/kumulos/android/AppStateWatcher.java
@@ -54,6 +54,10 @@ class AppStateWatcher implements Application.ActivityLifecycleCallbacks {
             listener.activityAvailable(current);
         }
     }
+    @UiThread
+    public void unregisterListener(AppStateChangedListener listener) {
+        listeners.remove(listener);
+    }
 
     @Override
     public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) { /* noop */ }

--- a/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
+++ b/kumulos/src/main/java/com/kumulos/android/FirebaseMessageHandler.java
@@ -31,9 +31,9 @@ public class FirebaseMessageHandler {
      * @param context
      * @param remoteMessage
      */
-    public static void onMessageReceived(@NonNull Context context, @Nullable RemoteMessage remoteMessage) {
+    public static boolean onMessageReceived(@NonNull Context context, @Nullable RemoteMessage remoteMessage) {
         if (null == remoteMessage) {
-            return;
+            return false;
         }
 
         Kumulos.log(TAG, "Received a push message");
@@ -43,7 +43,7 @@ public class FirebaseMessageHandler {
         String customStr = bundle.get("custom");
 
         if (null == customStr) {
-            return;
+            return false;
         }
 
         // Extract bundle
@@ -63,8 +63,9 @@ public class FirebaseMessageHandler {
             buttons = data.optJSONArray("k.buttons");
 
         } catch (JSONException e) {
-            Kumulos.log(TAG, "Push received had no ID/data/uri or was incorrectly formatted, ignoring...");
-            return;
+            Kumulos.log(TAG, "Push received shouldn't be processed by Kumulos or was incorrectly" +
+                    "formatted, ignoring...");
+            return false;
         }
 
         String bgn = bundle.get("bgn");
@@ -89,5 +90,6 @@ public class FirebaseMessageHandler {
         intent.putExtra(PushMessage.EXTRAS_KEY, pushMessage);
 
         context.sendBroadcast(intent);
+        return true;
     }
 }

--- a/kumulos/src/main/java/com/kumulos/android/HmsMessageHandler.java
+++ b/kumulos/src/main/java/com/kumulos/android/HmsMessageHandler.java
@@ -28,9 +28,9 @@ public class HmsMessageHandler {
      * @param context
      * @param remoteMessage
      */
-    public static void onMessageReceived(@NonNull Context context, @Nullable RemoteMessage remoteMessage) {
+    public static boolean onMessageReceived(@NonNull Context context, @Nullable RemoteMessage remoteMessage) {
         if (null == remoteMessage) {
-            return;
+            return false;
         }
 
         Kumulos.log(TAG, "Received a push message");
@@ -41,11 +41,11 @@ public class HmsMessageHandler {
             bundle = new JSONObject(remoteMessage.getData());
         } catch (JSONException e) {
             e.printStackTrace();
-            return;
+            return false;
         }
 
         if (!bundle.has("custom") || bundle.isNull("custom")) {
-            return;
+            return false;
         }
 
         int id;
@@ -63,8 +63,9 @@ public class HmsMessageHandler {
             id = data.getJSONObject("k.message").getJSONObject("data").getInt("id");
             buttons = data.optJSONArray("k.buttons");
         } catch (JSONException e) {
-            Kumulos.log(TAG, "Push received had no ID/data/uri or was incorrectly formatted, ignoring...");
-            return;
+            Kumulos.log(TAG, "Push received shouldn't be processed by Kumulos or was incorrectly formatted, " +
+                    "ignoring...");
+            return false;
         }
 
         String bgn = optNullableString(bundle, "bgn");
@@ -89,6 +90,7 @@ public class HmsMessageHandler {
         intent.putExtra(PushMessage.EXTRAS_KEY, pushMessage);
 
         context.sendBroadcast(intent);
+        return true;
     }
 
     private static String optNullableString(@NonNull JSONObject object, @NonNull String name) {

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessageView.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessageView.java
@@ -337,8 +337,8 @@ class InAppMessageView extends WebViewClient {
 
     @Override
     public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-        super.onReceivedSslError(view, handler, error);
-
+        handler.cancel();
+        
         closeDialog(currentActivity);
     }
 

--- a/kumulos/src/main/java/com/kumulos/android/InAppMessageView.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessageView.java
@@ -543,7 +543,7 @@ class InAppMessageView extends WebViewClient {
                 case BUTTON_ACTION_PUSH_REGISTER:
                     presenter.cancelCurrentPresentationQueue();
 
-                    Kumulos.pushRegister(currentActivity);
+                    Kumulos.pushRequestDeviceToken(currentActivity);
                     return;
             }
         }

--- a/kumulos/src/main/java/com/kumulos/android/Kumulos.java
+++ b/kumulos/src/main/java/com/kumulos/android/Kumulos.java
@@ -36,6 +36,8 @@ import java.util.concurrent.Executors;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
+
 import okhttp3.Call;
 import okhttp3.ConnectionSpec;
 import okhttp3.FormBody;
@@ -528,11 +530,12 @@ public final class Kumulos {
     //-- Push APIs
 
     /**
-     * Used to register the device installation with FCM to receive push notifications
+     * Used to register the device installation to receive push notifications.
+     * Prompts a notification permission request
      *
      * @param context
      */
-    public static void pushRegister(Context context) {
+    public static void pushRequestDeviceToken(Context context) {
         PushRegistration.RegisterTask task = new PushRegistration.RegisterTask(context);
         executorService.submit(task);
     }
@@ -602,12 +605,26 @@ public final class Kumulos {
             props.put("token", token);
             props.put("type", type.getValue());
             props.put("package", context.getPackageName());
+            props.put("areNotificationsEnabled", NotificationManagerCompat.from(context).areNotificationsEnabled());
         } catch (JSONException e) {
             e.printStackTrace();
             return;
         }
 
-        trackEvent(context, AnalyticsContract.EVENT_TYPE_PUSH_DEVICE_REGISTERED, props, System.currentTimeMillis(), true);
+        trackEventImmediately(context, AnalyticsContract.EVENT_TYPE_PUSH_DEVICE_REGISTERED, props);
+    }
+
+    static void notificationEnablementStatusChanged(@NonNull Context context, boolean notificationsEnabled) {
+        JSONObject props = new JSONObject();
+
+        try {
+            props.put("notificationsEnabled", notificationsEnabled);
+        } catch (JSONException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        trackEventImmediately(context, AnalyticsContract.EVENT_TYPE_PUSH_NOTIFICATION_ENABLEMENT_CHANGED, props);
     }
 
     /**

--- a/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
+++ b/kumulos/src/main/java/com/kumulos/android/PushBroadcastReceiver.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
 
 public class PushBroadcastReceiver extends BroadcastReceiver {
     public static final String TAG = PushBroadcastReceiver.class.getName();
@@ -91,11 +92,11 @@ public class PushBroadcastReceiver extends BroadcastReceiver {
             this.onBackgroundPush(context, pushMessage);
         }
 
-        if (!pushMessage.hasTitleAndMessage()) {
-            // Always show Notification if has title + message
-            return;
+        if (pushMessage.hasTitleAndMessage() && NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+            processPushMessage(context, pushMessage);
         }
-
+    }
+    private void processPushMessage(Context context, PushMessage pushMessage) {
         Notification.Builder builder = getNotificationBuilder(context, pushMessage);
         if (null == builder) {
             return;

--- a/kumulos/src/main/java/com/kumulos/android/RequestNotificationPermissionActivity.java
+++ b/kumulos/src/main/java/com/kumulos/android/RequestNotificationPermissionActivity.java
@@ -1,0 +1,35 @@
+package com.kumulos.android;
+
+import android.Manifest;
+import android.app.Activity;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+
+public class RequestNotificationPermissionActivity extends Activity {
+    private static final int REQ_CODE = 1;
+    private static final String TAG = RequestNotificationPermissionActivity.class.getName();
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            finish();
+            return;
+        }
+
+        boolean shouldShow = shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS);
+        Kumulos.log(TAG, "Should show perms req rationale? " + (shouldShow ? "YES" : "NO"));
+
+        requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, REQ_CODE);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        finish();
+    }
+
+}

--- a/kumulos/src/main/java/com/kumulos/android/SharedPrefs.java
+++ b/kumulos/src/main/java/com/kumulos/android/SharedPrefs.java
@@ -7,4 +7,5 @@ final class SharedPrefs {
     static final String IN_APP_ENABLED = "in_app_enabled";
     static final String IN_APP_LAST_SYNC_TIME = "in_app_last_sync_time";
     static final String DEFERRED_LINK_CHECKED_KEY = "kumulos_ddl_checked";
+    static final String KEY_NOTIFICATIONS_ENABLEMENT_STATUS = "notifications_enabled";
 }

--- a/kumulos/src/main/res/values/styles.xml
+++ b/kumulos/src/main/res/values/styles.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Kumulos.Transparent" parent="Theme.AppCompat.NoActionBar">
-        <item name="android:windowIsTranslucent">true</item>
+    <style name="Kumulos.Transparent" parent="android:Theme.Translucent.NoTitleBar">
         <item name="android:windowIsFloating">true</item>
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowNoTitle">true</item>
         <item name="android:backgroundDimEnabled">false</item>
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:windowAnimationStyle">@null</item>
     </style>
 </resources>

--- a/kumulos/src/main/res/values/styles.xml
+++ b/kumulos/src/main/res/values/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Kumulos.Transparent" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
+</resources>


### PR DESCRIPTION
### Description of Changes

Add explicit call to sslErrorHandler.cancel() as required for Google Play store security testing.
Whilst the super method was called and its implementation calls to cancel, this doesn't seem to be recognised by Play Store's security scanning tool.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [ ] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)

Post Release:

Update docs site with correct version number references

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/
- [ ] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/#changelog
