### PR TITLE
fix security warning

### DIFF
--- a/kumulos/src/main/java/com/kumulos/android/InAppMessageView.java
+++ b/kumulos/src/main/java/com/kumulos/android/InAppMessageView.java
@@ -337,7 +337,7 @@ class InAppMessageView extends WebViewClient {
 
     @Override
     public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-        super.onReceivedSslError(view, handler, error);
+        handler.cancel();
 
         closeDialog(currentActivity);
     }


### PR DESCRIPTION
### Description of Changes

Add explicit call to `sslErrorHandler.cancel()` as required for Google Play store security testing.

Whilst the super method was called and its implementation calls to cancel, this doesn't seem to be recognised by Play Store's security scanning tool.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `./gradlew assemble` passes w/ no errors

Bump versions in:

- [ ] README.md

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Verify & Publish release from [OSS Nexus UI](https://oss.sonatype.org/#stagingRepositories)

Post Release:

Update docs site with correct version number references

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/
- [ ] https://docs.kumulos.com/getting-started/integrate-app/

Update changelog:

- [ ] https://docs.kumulos.com/developer-guide/sdk-reference/android/#changelog
